### PR TITLE
Add irrigation valve hub support (HTV0540FRF)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # HomGar Cloud integration for Home Assistant
 
-Unofficial Home Assistant component for HomGar Cloud, supporting RF soil moisture and rain sensors via the HomGar cloud API.
+Unofficial Home Assistant component for HomGar Cloud, supporting RF soil moisture, rain, and irrigation valve control via the HomGar cloud API.
 
 ---
 
 ## Compatibility
 
 Tested with:
+
 - Hub: `HWG023WBRF-V2`
 - Soil moisture probes:
   - `HCS026FRF` (moisture-only)
@@ -23,6 +24,8 @@ Tested with:
   - `HCS0528ARF`
 - Pool + Ambient temp/humidity:
   - `HCS015ARF+`
+- Irrigation valve hub:
+  - `HTV0540FRF` (multi-zone; zone count detected automatically from device payload)
 
 The integration communicates with the same cloud endpoints as the HomGar app (`region3.homgarus.com`).
 
@@ -47,10 +50,47 @@ The integration communicates with the same cloud endpoints as the HomGar app (`r
   - CO2, temperature, humidity (HCS0530THO)
   - Pool temperature (HCS0528ARF)
   - Pool + ambient temperature and humidity (HCS015ARF+)
-- Attributes:
+  - **Irrigation valve control (HTV0540FRF)**:
+    - One `valve` entity per zone - open/close from the HA UI or automations
+    - One `number` entity per zone - configurable run duration (1-60 minutes, persisted across restarts)
+    - Zone count is detected automatically from the device payload; no hardcoded assumption about 1, 2, 3 or more zones
+    - Immediate state reflection after a command - no waiting for the next poll cycle
+    - State attributes: `duration_seconds`, `state_raw`
+- Attributes (sensors):
   - `rssi_dbm`
   - `battery_status_code`
   - `last_updated` (cloud timestamp)
+
+---
+
+## Irrigation valve usage
+
+Each zone appears as two entities in Home Assistant:
+
+| Entity type | Name example | Purpose |
+| --- | --- | --- |
+| `valve` | `Zone 1` | Open / close the zone |
+| `number` | `Zone 1 Duration` | Default run time in minutes (1–60) |
+
+**Opening a zone:**
+
+Call the `valve.open_valve` service. The zone will run for the duration currently set in the companion `number` entity (default 10 minutes). You can override the duration at service-call time using the `duration` attribute (value in seconds):
+
+```yaml
+service: valve.open_valve
+target:
+  entity_id: valve.my_valve_hub_zone_1
+data:
+  duration: 300   # 5 minutes (seconds)
+```
+
+**Closing a zone:**
+
+```yaml
+service: valve.close_valve
+target:
+  entity_id: valve.my_valve_hub_zone_1
+```
 
 ---
 
@@ -72,32 +112,6 @@ You can quickly add this repository to HACS by clicking the button below:
 ## Configuration
 
 Go to **Settings → Devices & Services → Add Integration** and search for **HomGar Cloud**. Enter your HomGar account credentials (email and area code) to connect.
-
----
-
-## Example manifest.json
-
-Below is the manifest file for this integration (as of version 0.2.6):
-
-```json
-{
-    "domain": "homgar",
-    "name": "HomGar Cloud",
-    "version": "0.2.6",
-    "documentation": "https://github.com/brettmeyerowitz/homeassistant-homgar",
-    "issue_tracker": "https://github.com/brettmeyerowitz/homeassistant-homgar/issues",
-    "requirements": [],
-    "codeowners": [
-        "@brettmeyerowitz"
-    ],
-    "config_flow": true,
-    "iot_class": "cloud_polling",
-    "integration_type": "hub",
-    "loggers": [
-        "custom_components.homgar"
-    ]
-}
-```
 
 ---
 

--- a/custom_components/homgar/__init__.py
+++ b/custom_components/homgar/__init__.py
@@ -11,7 +11,7 @@ from .homgar_api import HomGarClient
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[str] = ["sensor"]
+PLATFORMS: list[str] = ["sensor", "valve", "number"]
 
 
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:

--- a/custom_components/homgar/const.py
+++ b/custom_components/homgar/const.py
@@ -24,3 +24,4 @@ MODEL_CO2 = "HCS0530THO"             # CO2/Temp/Humidity
 MODEL_POOL = "HCS0528ARF"            # Pool/Temperature
 MODEL_POOL_PLUS = "HCS015ARF+"       # Pool + Ambient temp/humidity
 MODEL_DISPLAY_HUB = "HWS019WRF-V2"   # Smart+ Irrigation Display Hub
+MODEL_VALVE_HUB = "HTV0540FRF"       # irrigation valve hub (zone count detected from payload)

--- a/custom_components/homgar/coordinator.py
+++ b/custom_components/homgar/coordinator.py
@@ -20,11 +20,13 @@ from .const import (
     MODEL_POOL,
     MODEL_POOL_PLUS,
     MODEL_DISPLAY_HUB,
+    MODEL_VALVE_HUB,
 )
 from .homgar_api import (
     HomGarClient, HomGarApiError,
     decode_moisture_simple, decode_moisture_full, decode_rain,
     decode_temphum, decode_flowmeter, decode_co2, decode_pool, decode_pool_plus,
+    decode_valve_hub,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -60,14 +62,47 @@ class HomGarCoordinator(DataUpdateCoordinator):
             status_by_mid: dict[int, dict] = {}
             decoded_sensors: dict[str, dict] = {}
 
-            for hub in hubs:
-                mid = hub["mid"]
+            # Build the device list for the batch status call from hubs that have
+            # deviceName and productKey available (i.e. the valve hub and others
+            # that expose these fields).  Fall back to per-hub getDeviceStatus for
+            # any hub that does not have them.
+            batch_devices = [
+                {"deviceName": h["deviceName"], "mid": str(h["mid"]), "productKey": h["productKey"]}
+                for h in hubs
+                if h.get("deviceName") and h.get("productKey")
+            ]
+            fallback_mids = {
+                h["mid"] for h in hubs
+                if not (h.get("deviceName") and h.get("productKey"))
+            }
+
+            if batch_devices:
+                batch_results = await self._client.get_multiple_device_status(batch_devices)
+                # multipleDeviceStatus returns a list; index by mid for lookup below
+                for result in batch_results:
+                    result_mid = int(result.get("mid", 0))
+                    status_by_mid[result_mid] = result
+                _LOGGER.debug("Batch status fetched for %d devices", len(batch_devices))
+
+            for mid in fallback_mids:
                 status = await self._client.get_device_status(mid)
                 status_by_mid[mid] = status
+                _LOGGER.debug("Fallback status fetched for mid=%s", mid)
 
-                _LOGGER.debug("Fetched status for mid=%s: %s", mid, status)
+            for hub in hubs:
+                mid = hub["mid"]
+                status = status_by_mid.get(mid, {})
 
-                sub_status = {s["id"]: s for s in status.get("subDeviceStatus", [])}
+                _LOGGER.debug("Processing status for mid=%s: %s", mid, status)
+
+                # multipleDeviceStatus returns a 'status' list; getDeviceStatus returns
+                # 'subDeviceStatus'. Support both so the fallback path still works.
+                raw_status_list = (
+                    status.get("subDeviceStatus")
+                    or status.get("status")
+                    or []
+                )
+                sub_status = {s["id"]: s for s in raw_status_list if s.get("id")}
 
                 # Map addr -> subDevice
                 addr_map = {sd["addr"]: sd for sd in hub.get("subDevices", [])}
@@ -113,6 +148,8 @@ class HomGarCoordinator(DataUpdateCoordinator):
                             elif model == MODEL_DISPLAY_HUB:
                                 from .homgar_api import decode_hws019wrf_v2
                                 decoded = decode_hws019wrf_v2(raw_value)
+                            elif model == MODEL_VALVE_HUB:
+                                decoded = decode_valve_hub(raw_value)
                             else:
                                 # Store raw data for unknown models so users can report it
                                 decoded = {
@@ -167,6 +204,8 @@ class HomGarCoordinator(DataUpdateCoordinator):
                         "model": sub.get("model"),
                         "raw_status": s,
                         "data": decoded,
+                        "device_name": hub.get("deviceName"),
+                        "product_key": hub.get("productKey"),
                     }
 
                     _LOGGER.debug("Sensor entity key=%s info=%s", sensor_key, decoded_sensors[sensor_key])

--- a/custom_components/homgar/homgar_api.py
+++ b/custom_components/homgar/homgar_api.py
@@ -187,7 +187,85 @@ class HomGarClient:
         if data.get("code") != 0:
             raise HomGarApiError(f"getDeviceStatus failed: {data}")
         return data.get("data", {})
-    
+
+    async def get_multiple_device_status(self, devices: list[dict]) -> list[dict]:
+        """
+        Fetch status for multiple devices in a single call.
+
+        Each entry in devices should be a dict with keys:
+            deviceName, mid (str), productKey
+
+        Returns the list of device status dicts from the API response.
+        This is more efficient than calling get_device_status per hub.
+        """
+        await self.ensure_logged_in()
+        url = f"{self._base_url}/app/device/multipleDeviceStatus"
+        payload = {"devices": devices}
+        _LOGGER.debug("API call: get_multiple_device_status devices=%s", devices)
+        async with self._session.post(url, json=payload, headers=self._auth_headers()) as resp:
+            if resp.status != 200:
+                raise HomGarApiError(f"multipleDeviceStatus HTTP {resp.status}")
+            data = await resp.json()
+        _LOGGER.debug("API response: get_multiple_device_status data=%s", data)
+        if data.get("code") != 0:
+            raise HomGarApiError(f"multipleDeviceStatus failed: {data}")
+        return data.get("data", [])
+
+    async def control_work_mode(
+        self,
+        mid: int,
+        addr: int,
+        device_name: str,
+        product_key: str,
+        port: int,
+        mode: int,
+        duration: int,
+    ) -> dict:
+        """
+        Control a valve zone via the confirmed controlWorkMode endpoint.
+
+        Args:
+            mid:          Hub mid (device ID)
+            addr:         Sub-device address
+            device_name:  Hub deviceName field (e.g. "MAC-885721174638")
+            product_key:  Hub productKey field (e.g. "a3QrDxYPTM2")
+            port:         Zone number (1-based)
+            mode:         1 = open, 0 = close
+            duration:     Run time in seconds (ignored / set to 0 when closing)
+
+        Returns the full API response data dict on success.
+        """
+        await self.ensure_logged_in()
+        url = f"{self._base_url}/app/device/controlWorkMode"
+        payload = {
+            "deviceName": device_name,
+            "productKey": product_key,
+            "mid": str(mid),
+            "addr": addr,
+            "port": port,
+            "mode": mode,
+            "duration": duration,
+            "param": "",
+        }
+        _LOGGER.debug("control_work_mode url=%s payload=%s", url, payload)
+        async with self._session.post(url, json=payload, headers=self._auth_headers()) as resp:
+            if resp.status != 200:
+                raise HomGarApiError(f"controlWorkMode HTTP {resp.status}")
+            data = await resp.json()
+        _LOGGER.debug("control_work_mode response: %s", data)
+        code = data.get("code")
+        if code == 4:
+            # Code 4 = device already in requested state or transitioning - not fatal.
+            _LOGGER.warning(
+                "controlWorkMode returned code 4 (busy/already in state), "
+                "treating as non-fatal: %s", data
+            )
+        elif code != 0:
+            raise HomGarApiError(f"controlWorkMode failed: {data}")
+        # Return the updated state payload string so callers can apply it immediately
+        # without waiting for the next poll cycle (which may return stale cached data).
+        return data.get("data", {}).get("state")
+
     # --- Payload decoding helpers ---
 
 def _parse_homgar_payload(raw: str) -> list[int]:
@@ -507,3 +585,179 @@ def decode_pool_plus(raw: str) -> dict:
         "humidity_high": humidity_high,
         "raw_bytes": b,
     }
+
+
+
+# ---------------------------------------------------------------------------
+# HTV0540FRF - irrigation valve hub
+# Uses an 11# prefixed TLV-encoded payload distinct from the 10# sensor format.
+# ---------------------------------------------------------------------------
+
+# Type byte -> value width in bytes.  0x20 is a flag with no following value bytes.
+_TLV_TYPE_WIDTHS: dict[int, int] = {
+    0xD8: 1,
+    0xDC: 1,
+    0xB7: 4,
+    0xAD: 2,
+    0xE1: 2,
+    0xC4: 1,
+    0xC5: 1,
+    0xC6: 1,
+    0x20: 0,
+}
+
+# DP IDs for zone state and duration (confirmed via payload capture)
+# Zone N state DP   = _DP_HUB_STATE + N  (0x19 = zone 1, 0x1A = zone 2, ...)
+# Zone N duration DP = _DP_BASE_DURATION + N (0x25 = zone 1, 0x26 = zone 2, ...)
+_DP_HUB_STATE = 0x18
+_DP_BASE_DURATION = 0x24  # zone N duration DP = 0x24 + N
+
+# Value written to the state DP when a zone is open (observed: 0x21)
+_ZONE_OPEN_STATE_BYTE = 0x21
+
+
+def _parse_tlv_payload(raw: str) -> dict[int, tuple[int, int | None]]:
+    """
+    Parse a HomGar TLV payload with an '11#' prefix.
+
+    Returns a dict mapping dp_id -> (type_byte, value_int).
+    For flag-type DPs (type 0x20, zero-width) value_int is None.
+    Big-endian byte order is used for multi-byte values except for the
+    zone duration DPs (0x25/26/27) which are little-endian - the caller
+    is responsible for endian interpretation.
+    """
+    if not raw:
+        raise ValueError("Empty payload")
+    # Strip frame counter prefix: '11#' (or '10#' for other devices)
+    if "#" in raw:
+        raw = raw.split("#", 1)[1]
+
+    if len(raw) % 2 != 0:
+        raise ValueError(f"Odd-length hex payload: {raw!r}")
+
+    data = bytes.fromhex(raw)
+    result: dict[int, tuple[int, int | None]] = {}
+    i = 0
+
+    while i < len(data):
+        dp = data[i]
+        if i + 1 >= len(data):
+            break
+        type_byte = data[i + 1]
+        if type_byte not in _TLV_TYPE_WIDTHS:
+            # Unknown type - advance one byte and try to resync
+            i += 1
+            continue
+        width = _TLV_TYPE_WIDTHS[type_byte]
+        if i + 2 + width > len(data):
+            break
+        value_bytes = data[i + 2: i + 2 + width]
+        value_int = int.from_bytes(value_bytes, "big") if width > 0 else None
+        result[dp] = (type_byte, value_int, value_bytes)  # type: ignore[assignment]
+        i += 2 + width
+
+    return result  # type: ignore[return-value]
+
+
+def decode_valve_hub(raw: str) -> dict:
+    """
+    Decode an irrigation valve hub TLV payload (e.g. HTV0540FRF).
+
+    Confirmed DP map (derived from live payload capture):
+      0x18      hub online state     DC  1-byte  0x01 = online
+      0x18+N    zone N open state    D8  1-byte  0x00 = closed, non-zero = open
+      0x24+N    zone N run duration  AD  2-byte  little-endian seconds
+
+    Zone state DPs are detected dynamically from the payload so that hubs with
+    any number of zones (1, 2, 3, 4, ...) are handled without code changes.
+    """
+    tlv = _parse_tlv_payload(raw)
+
+    def get_val(dp: int) -> int | None:
+        entry = tlv.get(dp)
+        return entry[1] if entry else None  # type: ignore[index]
+
+    def get_raw_bytes(dp: int) -> bytes:
+        entry = tlv.get(dp)
+        return entry[2] if entry else b""  # type: ignore[index]
+
+    hub_state = get_val(_DP_HUB_STATE)
+
+    # Dynamically detect zones: any DP of type 0xD8 (state byte) with
+    # dp > _DP_HUB_STATE follows the pattern zone_num = dp - _DP_HUB_STATE.
+    zones: dict[int, dict] = {}
+    for dp, entry in tlv.items():
+        type_byte = entry[0]
+        if type_byte != 0xD8 or dp <= _DP_HUB_STATE:
+            continue
+        zone_num = dp - _DP_HUB_STATE
+        state_val = entry[1]
+        dur_dp = _DP_BASE_DURATION + zone_num
+        dur_bytes = get_raw_bytes(dur_dp)
+        duration_s = int.from_bytes(dur_bytes, "little") if len(dur_bytes) == 2 else None
+        zones[zone_num] = {
+            # Bit 0 = valve physically open. 0x21 = open, 0x20 = closing/transitional, 0x00 = closed.
+            "open": bool(state_val & 0x01) if state_val is not None else None,
+            "state_raw": state_val,
+            "duration_seconds": duration_s,
+        }
+
+    return {
+        "type": "valve_hub",
+        "hub_online": hub_state == 1,
+        "zones": zones,
+        "raw_tlv": {f"0x{k:02X}": v[1] for k, v in tlv.items()},  # type: ignore[index]
+    }
+
+
+def build_valve_open_command(zone_num: int, duration_seconds: int) -> str:
+    """
+    Build the hex command string to open a single valve zone for a given duration.
+
+    The returned string is the raw hex payload (without any '11#' prefix).
+    It should be passed directly to HomGarClient.send_device_command().
+
+    NOTE: The write endpoint URL has not been confirmed via traffic capture.
+    Test with caution.  See HomGarClient.send_device_command() for details.
+
+    Args:
+        zone_num: zone number (1-based), e.g. 1, 2, 3, 4 ...
+        duration_seconds: how long to run, max 3600 (1 hour)
+    """
+    if zone_num < 1:
+        raise ValueError(f"zone_num must be >= 1, got {zone_num}")
+    if not (1 <= duration_seconds <= 3600):
+        raise ValueError(f"duration_seconds must be 1-3600, got {duration_seconds}")
+
+    state_dp = _DP_HUB_STATE + zone_num
+    dur_dp = _DP_BASE_DURATION + zone_num
+
+    # State byte: D8 type, value = _ZONE_OPEN_STATE_BYTE
+    state_bytes = bytes([state_dp, 0xD8, _ZONE_OPEN_STATE_BYTE])
+
+    # Duration: AD type, 2-byte little-endian seconds
+    dur_le = duration_seconds.to_bytes(2, "little")
+    dur_bytes = bytes([dur_dp, 0xAD]) + dur_le
+
+    return (state_bytes + dur_bytes).hex().upper()
+
+
+def build_valve_close_command(zone_num: int) -> str:
+    """
+    Build the hex command string to close a single valve zone.
+
+    The returned string is the raw hex payload (without any '11#' prefix).
+
+    Args:
+        zone_num: zone number (1-based), e.g. 1, 2, 3, 4 ...
+    """
+    if zone_num < 1:
+        raise ValueError(f"zone_num must be >= 1, got {zone_num}")
+
+    state_dp = _DP_HUB_STATE + zone_num
+    dur_dp = _DP_BASE_DURATION + zone_num
+
+    state_bytes = bytes([state_dp, 0xD8, 0x00])
+    dur_bytes = bytes([dur_dp, 0xAD, 0x00, 0x00])
+
+    return (state_bytes + dur_bytes).hex().upper()

--- a/custom_components/homgar/manifest.json
+++ b/custom_components/homgar/manifest.json
@@ -1,7 +1,7 @@
 {
     "domain": "homgar",
     "name": "HomGar Cloud",
-    "version": "0.2.8",
+    "version": "0.3.0",
     "documentation": "https://github.com/brettmeyerowitz/homeassistant-homgar",
     "issue_tracker": "https://github.com/brettmeyerowitz/homeassistant-homgar/issues",
     "requirements": [],

--- a/custom_components/homgar/number.py
+++ b/custom_components/homgar/number.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.number import NumberEntity, NumberMode
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfTime
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, MODEL_VALVE_HUB
+from .coordinator import HomGarCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+DURATION_MIN_MINUTES = 1
+DURATION_MAX_MINUTES = 60
+DURATION_STEP_MINUTES = 1
+DURATION_DEFAULT_MINUTES = 10
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    data = hass.data[DOMAIN][entry.entry_id]
+    coordinator: HomGarCoordinator = data["coordinator"]
+
+    sensors_cfg = coordinator.data.get("sensors", {})
+    entities: list[HomGarZoneDurationNumber] = []
+
+    for key, info in sensors_cfg.items():
+        if info.get("model") != MODEL_VALVE_HUB:
+            continue
+
+        decoded = info.get("data") or {}
+        zones: dict = decoded.get("zones", {})
+
+        for zone_num in sorted(zones.keys()):
+            entities.append(
+                HomGarZoneDurationNumber(coordinator, key, info, zone_num)
+            )
+            _LOGGER.debug(
+                "Creating duration number entity: key=%s zone=%s",
+                key, zone_num,
+            )
+
+    if entities:
+        async_add_entities(entities)
+
+
+class HomGarZoneDurationNumber(CoordinatorEntity, NumberEntity, RestoreEntity):
+    """Configurable run duration (in minutes) for a single irrigation zone.
+
+    The value is restored on HA restart via RestoreEntity.  When a valve is
+    opened without an explicit duration override in the service call data,
+    valve.py reads this entity's current value and converts it to seconds.
+    """
+
+    _attr_native_min_value = DURATION_MIN_MINUTES
+    _attr_native_max_value = DURATION_MAX_MINUTES
+    _attr_native_step = DURATION_STEP_MINUTES
+    _attr_native_unit_of_measurement = UnitOfTime.MINUTES
+    _attr_mode = NumberMode.BOX
+    _attr_icon = "mdi:timer-outline"
+
+    def __init__(
+        self,
+        coordinator: HomGarCoordinator,
+        sensor_key: str,
+        sensor_info: dict,
+        zone_num: int,
+    ) -> None:
+        super().__init__(coordinator)
+        self._sensor_key = sensor_key
+        self._sensor_info = sensor_info
+        self._zone_num = zone_num
+        self._current_value: float = DURATION_DEFAULT_MINUTES
+
+        hid = sensor_info["hid"]
+        mid = sensor_info["mid"]
+        addr = sensor_info["addr"]
+        sub_name = sensor_info.get("sub_name") or f"Valve Hub {addr}"
+
+        self._attr_unique_id = f"homgar_{hid}_{mid}_{addr}_zone{zone_num}_duration"
+        self._attr_name = f"{sub_name} Zone {zone_num} Duration"
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        last_state = await self.async_get_last_state()
+        if last_state is not None:
+            try:
+                restored = float(last_state.state)
+                if DURATION_MIN_MINUTES <= restored <= DURATION_MAX_MINUTES:
+                    self._current_value = restored
+                    _LOGGER.debug(
+                        "Restored duration for %s: %s min",
+                        self._attr_unique_id, restored,
+                    )
+            except (ValueError, TypeError):
+                pass
+
+    @property
+    def native_value(self) -> float:
+        return self._current_value
+
+    async def async_set_native_value(self, value: float) -> None:
+        self._current_value = value
+        self.async_write_ha_state()
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        hid = self._sensor_info["hid"]
+        mid = self._sensor_info["mid"]
+        addr = self._sensor_info["addr"]
+        sub_name = self._sensor_info.get("sub_name") or f"Valve Hub {addr}"
+        model = self._sensor_info.get("model") or "Unknown"
+        return {
+            "identifiers": {(DOMAIN, f"{hid}_{mid}_{addr}")},
+            "name": sub_name,
+            "manufacturer": "HomGar",
+            "model": model,
+        }

--- a/custom_components/homgar/valve.py
+++ b/custom_components/homgar/valve.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.valve import (
+    ValveEntity,
+    ValveEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, MODEL_VALVE_HUB
+from .coordinator import HomGarCoordinator
+from .homgar_api import decode_valve_hub
+# build_valve_open_command / build_valve_close_command retained in homgar_api for reference
+
+_LOGGER = logging.getLogger(__name__)
+
+# Default run duration used when HA opens a valve without an explicit duration.
+# Users can override by calling the valve.open_valve service with a duration attr.
+DEFAULT_DURATION_SECONDS = 600  # 10 minutes
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    data = hass.data[DOMAIN][entry.entry_id]
+    coordinator: HomGarCoordinator = data["coordinator"]
+
+    sensors_cfg = coordinator.data.get("sensors", {})
+    entities: list[HomGarValveEntity] = []
+
+    for key, info in sensors_cfg.items():
+        if info.get("model") != MODEL_VALVE_HUB:
+            continue
+
+        decoded = info.get("data") or {}
+        zones: dict = decoded.get("zones", {})
+
+        # Create one valve entity per zone that reported in the payload.
+        # Zones absent from the payload are not created - avoids phantom entities
+        # if the device reports fewer zones than the model name implies.
+        for zone_num in sorted(zones.keys()):
+            entities.append(
+                HomGarValveEntity(coordinator, key, info, zone_num)
+            )
+            _LOGGER.debug(
+                "Creating valve entity: key=%s zone=%s model=%s",
+                key, zone_num, info.get("model"),
+            )
+
+    if entities:
+        async_add_entities(entities)
+
+
+class HomGarValveEntity(CoordinatorEntity, ValveEntity):
+    """Represents a single irrigation zone on a HomGar valve hub."""
+
+    _attr_should_poll = False
+    _attr_reports_position = False
+    _attr_supported_features = ValveEntityFeature.OPEN | ValveEntityFeature.CLOSE
+
+    def __init__(
+        self,
+        coordinator: HomGarCoordinator,
+        sensor_key: str,
+        sensor_info: dict,
+        zone_num: int,
+    ) -> None:
+        super().__init__(coordinator)
+        self._sensor_key = sensor_key
+        self._sensor_info = sensor_info
+        self._zone_num = zone_num
+
+        hid = sensor_info["hid"]
+        mid = sensor_info["mid"]
+        addr = sensor_info["addr"]
+        sub_name = sensor_info.get("sub_name") or f"Valve Hub {addr}"
+
+        self._attr_unique_id = f"homgar_{hid}_{mid}_{addr}_zone{zone_num}"
+        self._attr_name = f"{sub_name} Zone {zone_num}"
+
+    # ------------------------------------------------------------------
+    # Coordinator data helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def _zone_data(self) -> dict | None:
+        sensors = self.coordinator.data.get("sensors", {})
+        info = sensors.get(self._sensor_key)
+        if not info:
+            return None
+        decoded = info.get("data")
+        if not decoded:
+            return None
+        return decoded.get("zones", {}).get(self._zone_num)
+
+    # ------------------------------------------------------------------
+    # Entity properties
+    # ------------------------------------------------------------------
+
+    @property
+    def available(self) -> bool:
+        sensors = self.coordinator.data.get("sensors", {})
+        info = sensors.get(self._sensor_key)
+        if not info:
+            return False
+        decoded = info.get("data")
+        if not decoded:
+            return False
+        return decoded.get("hub_online", False)
+
+    @property
+    def is_closed(self) -> bool | None:
+        zone = self._zone_data
+        if zone is None or zone.get("open") is None:
+            return None
+        return not zone["open"]
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        attrs: dict[str, Any] = {}
+        zone = self._zone_data
+        if zone:
+            dur = zone.get("duration_seconds")
+            if dur is not None:
+                attrs["duration_seconds"] = dur
+            attrs["state_raw"] = zone.get("state_raw")
+        return attrs
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        hid = self._sensor_info["hid"]
+        mid = self._sensor_info["mid"]
+        addr = self._sensor_info["addr"]
+        sub_name = self._sensor_info.get("sub_name") or f"Valve Hub {addr}"
+        model = self._sensor_info.get("model") or "Unknown"
+        return {
+            "identifiers": {(DOMAIN, f"{hid}_{mid}_{addr}")},
+            "name": sub_name,
+            "manufacturer": "HomGar",
+            "model": model,
+        }
+
+    # ------------------------------------------------------------------
+    # Control
+    # ------------------------------------------------------------------
+
+    def _get_configured_duration_seconds(self) -> int:
+        """Look up the companion duration number entity for this zone and convert
+        its value (minutes) to seconds.  Falls back to DEFAULT_DURATION_SECONDS
+        if the entity is not yet available.
+
+        Uses the entity registry to resolve unique_id -> entity_id so the lookup
+        is not sensitive to HA auto-generated entity_id naming."""
+        from homeassistant.helpers import entity_registry as er
+        hid = self._sensor_info["hid"]
+        mid = self._sensor_info["mid"]
+        addr = self._sensor_info["addr"]
+        unique_id = f"homgar_{hid}_{mid}_{addr}_zone{self._zone_num}_duration"
+        registry = er.async_get(self.hass)
+        entity_id = registry.async_get_entity_id("number", "homgar", unique_id)
+        if entity_id:
+            state = self.hass.states.get(entity_id)
+            if state is not None:
+                try:
+                    minutes = float(state.state)
+                    return max(1, int(minutes * 60))
+                except (ValueError, TypeError):
+                    pass
+        _LOGGER.debug(
+            "Duration entity for unique_id=%s not found, falling back to default %ss",
+            unique_id, DEFAULT_DURATION_SECONDS,
+        )
+        return DEFAULT_DURATION_SECONDS
+
+    def _apply_response_state(self, raw_state: str | None) -> None:
+        """Decode the state string returned by controlWorkMode and inject it
+        into the coordinator data immediately, bypassing the poll cycle.
+        The API often returns a stale cached payload on the next poll so this
+        ensures HA reflects the actual device state without delay."""
+        if not raw_state:
+            return
+        decoded = decode_valve_hub(raw_state)
+        if not decoded:
+            return
+        current = dict(self.coordinator.data)
+        sensors = dict(current.get("sensors", {}))
+        if self._sensor_key not in sensors:
+            return
+        entry = dict(sensors[self._sensor_key])
+        entry["data"] = decoded
+        sensors[self._sensor_key] = entry
+        current["sensors"] = sensors
+        self.coordinator.async_set_updated_data(current)
+
+    # ------------------------------------------------------------------
+    async def async_open_valve(self, **kwargs: Any) -> None:
+        if "duration" in kwargs:
+            duration = int(kwargs["duration"])
+        else:
+            duration = self._get_configured_duration_seconds()
+        mid = self._sensor_info["mid"]
+        addr = self._sensor_info["addr"]
+        device_name = self._sensor_info.get("device_name") or ""
+        product_key = self._sensor_info.get("product_key") or ""
+
+        _LOGGER.debug(
+            "Opening valve mid=%s addr=%s zone=%s duration=%ss",
+            mid, addr, self._zone_num, duration,
+        )
+
+        client = self.coordinator._client
+        response_state = await client.control_work_mode(
+            mid=mid,
+            addr=addr,
+            device_name=device_name,
+            product_key=product_key,
+            port=self._zone_num,
+            mode=1,
+            duration=duration,
+        )
+        self._apply_response_state(response_state)
+
+    async def async_close_valve(self, **kwargs: Any) -> None:
+        mid = self._sensor_info["mid"]
+        addr = self._sensor_info["addr"]
+        device_name = self._sensor_info.get("device_name") or ""
+        product_key = self._sensor_info.get("product_key") or ""
+
+        _LOGGER.debug(
+            "Closing valve mid=%s addr=%s zone=%s",
+            mid, addr, self._zone_num,
+        )
+
+        client = self.coordinator._client
+        response_state = await client.control_work_mode(
+            mid=mid,
+            addr=addr,
+            device_name=device_name,
+            product_key=product_key,
+            port=self._zone_num,
+            mode=0,
+            duration=0,
+        )
+        self._apply_response_state(response_state)


### PR DESCRIPTION
## Summary

Adds control support for the HTV0540FRF irrigation valve hub.

- **Valve entities** - one per zone, open/close from the HA UI or automations
- **Duration number entities** - configurable run time per zone (1-60 min),
  persisted across HA restarts via `RestoreEntity`
- **Dynamic zone detection** - zone count is read from the device payload
  rather than hardcoded, so hubs with 1, 2, 3 or more zones all work without
  code changes
- **Batch status API** - coordinator now uses `multipleDeviceStatus` for
  devices that expose `deviceName`/`productKey`, with a per-device fallback
  for others
- **Immediate state reflection** - after an open/close command the response
  payload is decoded and injected directly into the coordinator, so HA state
  updates without waiting for the next poll cycle

## Tested with

- Hub: `HWG023WBRF-V2`
- Valve hub: `HTV0540FRF` (3 zones confirmed working; dynamic detection
  tested by reading payload directly)
- Existing sensor types unaffected - no changes to sensor decoding logic

<img width="1037" height="117" alt="image" src="https://github.com/user-attachments/assets/aebd2931-25b7-48a2-8113-6230af17d33e" />
<img width="1042" height="520" alt="image" src="https://github.com/user-attachments/assets/afdf62e3-d7eb-44d4-b28a-8e2e6185f9f3" />

## Notes

- The `controlWorkMode` endpoint and TLV payload format were confirmed via
  live traffic capture against the HomGar app
- Existing sensor behaviour is unchanged