### PR TITLE
fix: update config flow to use renamed API methods after modular refactor

### DIFF
--- a/custom_components/homgar/config_flow.py
+++ b/custom_components/homgar/config_flow.py
@@ -56,8 +56,9 @@ class HomGarConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             client = HomGarClient(area_code, email, password, session, app_type)
 
             try:
-                await client.ensure_logged_in()
-                homes = await client.list_homes()
+                if not await client.login():
+                    raise HomGarApiError("Login failed")
+                homes = await client.get_homes()
                 _LOGGER.info("Found %d homes for app_type %s", len(homes), app_type)
                 _LOGGER.debug("Homes data: %s", homes)
             except HomGarApiError:
@@ -183,8 +184,9 @@ class HomGarConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             client = HomGarClient(area_code, email, password, session, app_type)
 
             try:
-                await client.ensure_logged_in()
-                homes = await client.list_homes()
+                if not await client.login():
+                    raise HomGarApiError("Login failed")
+                homes = await client.get_homes()
                 _LOGGER.info("Found %d homes for reconfigure", len(homes))
             except HomGarApiError:
                 _LOGGER.exception("Error logging in to HomGar during reconfigure")


### PR DESCRIPTION
## Summary
- Config flow was calling `ensure_logged_in()` and `list_homes()` which were removed during the API modular refactor (4844b05)
- Updated to use `login()` and `get_homes()` with proper error handling for the `bool` return type
- Fixes `AttributeError: 'HomGarClient' object has no attribute 'ensure_logged_in'` when attempting to log in
- This should resolve https://github.com/brettmeyerowitz/homeassistant-homgar/issues/13