### PR TITLE
fix: restore API client methods broken during modular refactor

### DIFF
--- a/custom_components/homgar/api/client.py
+++ b/custom_components/homgar/api/client.py
@@ -57,117 +57,96 @@ class HomGarClient:
     def restore_tokens(self, data: dict) -> None:
         """Restore tokens from config entry data."""
         from ..const import CONF_TOKEN, CONF_REFRESH_TOKEN, CONF_TOKEN_EXPIRES_AT
-        
+
         self._token = data.get(CONF_TOKEN)
         self._refresh_token = data.get(CONF_REFRESH_TOKEN)
         ts = data.get(CONF_TOKEN_EXPIRES_AT)
-        try:
-            self._token_expires_at = datetime.fromisoformat(ts) if ts else None
-        except (ValueError, TypeError):
-            self._token_expires_at = None
+        if ts is not None:
+            try:
+                self._token_expires_at = datetime.fromtimestamp(ts, tz=timezone.utc)
+            except (TypeError, ValueError, OSError):
+                self._token_expires_at = None
 
     def export_tokens(self) -> dict:
-        """Export tokens for config entry storage."""
+        """Export current token state as a dict for config entry updates."""
         from ..const import CONF_TOKEN, CONF_REFRESH_TOKEN, CONF_TOKEN_EXPIRES_AT
-        
+
         return {
             CONF_TOKEN: self._token,
             CONF_REFRESH_TOKEN: self._refresh_token,
-            CONF_TOKEN_EXPIRES_AT: self._token_expires_at.isoformat() if self._token_expires_at else None,
+            CONF_TOKEN_EXPIRES_AT: int(self._token_expires_at.timestamp()) if self._token_expires_at else None,
         }
 
-    def is_token_valid(self) -> bool:
-        """Check if current token is valid and not expired."""
-        if not self._token:
+    def _token_valid(self) -> bool:
+        if not self._token or not self._token_expires_at:
             return False
-        if not self._token_expires_at:
-            return True  # No expiry info, assume valid
-        return datetime.now(timezone.utc) < self._token_expires_at
+        # refresh a little before expiry
+        return datetime.now(timezone.utc) < (self._token_expires_at - timedelta(minutes=5))
 
-    # --- authentication ---
+    # --- login / auth ---
 
-    async def login(self) -> bool:
-        """Perform login and store tokens."""
-        url = f"{self._base_url}/app/login"
+    async def ensure_logged_in(self) -> None:
+        if self._token_valid():
+            return
+        await self._login()
+
+    async def _login(self) -> None:
+        """Login with areaCode/email/password and store token info."""
+        url = f"{self._base_url}/auth/basic/app/login"
+
+        # Client-side MD5 hashing as per app/Postman flow
+        md5 = hashlib.md5(self._password.encode("utf-8")).hexdigest()
+
+        # Device ID is required; generate deterministic 16 bytes hex
+        device_id = hashlib.md5(f"{self._email}{self._area_code}".encode("utf-8")).hexdigest()
+
         payload = {
             "areaCode": self._area_code,
-            "email": self._email,
-            "password": self._password,
-            "appCode": self._app_code,
+            "phoneOrEmail": self._email,
+            "password": md5,
+            "deviceId": device_id,
         }
-        async with self._session.post(url, json=payload) as resp:
-            if resp.status != 200:
-                _LOGGER.error("Login failed: %d %s", resp.status, await resp.text())
-                return False
-            data = await resp.json()
-            if data.get("code") != 0:
-                _LOGGER.error("Login API error: %s", data.get("msg"))
-                return False
-            self._token = data["data"]["token"]
-            self._refresh_token = data["data"]["refreshToken"]
-            # Set expiry to 7 days from now (typical for JWT)
-            self._token_expires_at = datetime.now(timezone.utc) + timedelta(days=7)
-            _LOGGER.info("Login successful")
-            return True
 
-    async def refresh_token(self) -> bool:
-        """Refresh access token using refresh token."""
-        if not self._refresh_token:
-            return await self.login()
-        
-        url = f"{self._base_url}/app/refreshToken"
-        payload = {
-            "refreshToken": self._refresh_token,
-        }
-        async with self._session.post(url, json=payload) as resp:
-            if resp.status != 200:
-                _LOGGER.warning("Token refresh failed: %d %s", resp.status, await resp.text())
-                return await self.login()
-            data = await resp.json()
-            if data.get("code") != 0:
-                _LOGGER.warning("Token refresh API error: %s", data.get("msg"))
-                return await self.login()
-            self._token = data["data"]["token"]
-            self._token_expires_at = datetime.now(timezone.utc) + timedelta(days=7)
-            _LOGGER.info("Token refreshed")
-            return True
+        _LOGGER.debug("HomGar login request for %s with appCode=%s", self._email, self._app_code)
 
-    async def _ensure_auth(self) -> None:
-        """Ensure we have a valid token, refreshing if necessary."""
-        if not self.is_token_valid():
-            if not await self.refresh_token():
-                raise HomGarApiError("Authentication failed")
+        async with self._session.post(url, json=payload, headers={"Content-Type": "application/json", "lang": "en", "appCode": self._app_code}) as resp:
+            if resp.status != 200:
+                raise HomGarApiError(f"Login HTTP {resp.status}")
+            data = await resp.json()
+
+        if data.get("code") != 0 or "data" not in data:
+            raise HomGarApiError(f"Login failed: {data}")
+
+        d = data["data"]
+        self._token = d["token"]
+        self._refresh_token = d.get("refreshToken")
+        token_expired_secs = d.get("tokenExpired", 0)
+        ts_server = data.get("ts")  # ms since epoch
+        if ts_server:
+            base = datetime.fromtimestamp(ts_server / 1000, tz=timezone.utc)
+        else:
+            base = datetime.now(timezone.utc)
+        self._token_expires_at = base + timedelta(seconds=token_expired_secs)
+
+        _LOGGER.info("HomGar login successful; token expires in %s seconds", token_expired_secs)
 
     # --- API calls ---
 
-    async def get_homes(self) -> list:
-        """Get list of homes for the user."""
-        await self._ensure_auth()
-        url = f"{self._base_url}/app/home/list"
+    async def list_homes(self) -> list[dict]:
+        await self.ensure_logged_in()
+        url = f"{self._base_url}/app/member/appHome/list"
+        _LOGGER.debug("API call: list_homes URL=%s", url)
         async with self._session.get(url, headers=self._auth_headers()) as resp:
             if resp.status != 200:
-                raise HomGarApiError(f"Failed to get homes: {resp.status}")
+                raise HomGarApiError(f"list_homes HTTP {resp.status}")
             data = await resp.json()
-            if data.get("code") != 0:
-                raise HomGarApiError(f"Homes API error: {data.get('msg')}")
-            return data.get("data", [])
-
-    async def get_devices(self, home_id: int) -> list:
-        """Get devices for a specific home."""
-        await self._ensure_auth()
-        url = f"{self._base_url}/app/device/list"
-        params = {"homeId": home_id}
-        async with self._session.get(url, headers=self._auth_headers(), params=params) as resp:
-            if resp.status != 200:
-                raise HomGarApiError(f"Failed to get devices: {resp.status}")
-            data = await resp.json()
-            if data.get("code") != 0:
-                raise HomGarApiError(f"Devices API error: {data.get('msg')}")
-            return data.get("data", [])
+        _LOGGER.debug("API response: list_homes data=%s", data)
+        if data.get("code") != 0:
+            raise HomGarApiError(f"list_homes failed: {data}")
+        return data.get("data", [])
 
     async def get_devices_by_hid(self, hid: int) -> list[dict]:
-        """Get devices by home ID (HID)."""
-        await self._ensure_auth()
+        await self.ensure_logged_in()
         url = f"{self._base_url}/app/device/getDeviceByHid"
         params = {"hid": hid}
         _LOGGER.debug("API call: get_devices_by_hid URL=%s params=%s", url, params)
@@ -180,11 +159,11 @@ class HomGarClient:
             raise HomGarApiError(f"getDeviceByHid failed: {data}")
         return data.get("data", [])
 
-    async def get_multiple_device_status(self, devices: list) -> list[dict]:
-        """Get status for multiple devices in one call."""
-        await self._ensure_auth()
+    async def get_multiple_device_status(self, devices: list[dict]) -> list[dict]:
+        """Get status for multiple devices in one API call (more efficient)."""
+        await self.ensure_logged_in()
         url = f"{self._base_url}/app/device/multipleDeviceStatus"
-        
+
         # Format devices array as expected by API
         device_list = []
         for device in devices:
@@ -193,33 +172,32 @@ class HomGarClient:
                 "mid": device["mid"],
                 "productKey": device.get("productKey", "")
             })
-        
+
         payload = {"devices": device_list}
         _LOGGER.debug("API call: get_multiple_device_status URL=%s payload=%s", url, payload)
-        async with self._session.post(url, headers=self._auth_headers(), json=payload) as resp:
+        async with self._session.post(url, json=payload, headers=self._auth_headers()) as resp:
             if resp.status != 200:
-                raise HomGarApiError(f"Failed to get device status: {resp.status}")
+                raise HomGarApiError(f"multipleDeviceStatus HTTP {resp.status}")
             data = await resp.json()
         _LOGGER.debug("API response: get_multiple_device_status data=%s", data)
         if data.get("code") != 0:
-            raise HomGarApiError(f"Device status API error: {data.get('msg')}")
-        
-        # Convert response format - API returns "status" but coordinator expects "subDeviceStatus"
-        response_data = data.get("data", [])
+            raise HomGarApiError(f"multipleDeviceStatus failed: {data}")
+
+        # Convert response format to match individual device status format
+        # Response has: [{"propVer": X, "status": [...], "mid": Y, "iotId": Z}, ...]
+        # We need: [{"mid": Y, "subDeviceStatus": [...]}]
         converted_data = []
-        for device in response_data:
-            converted_device = device.copy()
-            if "status" in device:
-                converted_device["subDeviceStatus"] = device["status"]
-                # Remove the original "status" to avoid confusion
-                del converted_device["status"]
-            converted_data.append(converted_device)
-        
+        for device_data in data.get("data", []):
+            converted_data.append({
+                "mid": device_data["mid"],
+                "subDeviceStatus": device_data.get("status", [])
+            })
+
         return converted_data
 
     async def get_device_status(self, mid: int) -> dict:
         """Get status for a single device by MID."""
-        await self._ensure_auth()
+        await self.ensure_logged_in()
         url = f"{self._base_url}/app/device/getDeviceStatus"
         params = {"mid": mid}
         _LOGGER.debug("API call: get_device_status URL=%s params=%s", url, params)
@@ -234,7 +212,7 @@ class HomGarClient:
 
     async def set_device_state(self, home_id: int, device_name: str, mid: int, product_key: str, state: dict) -> bool:
         """Set device state."""
-        await self._ensure_auth()
+        await self.ensure_logged_in()
         url = f"{self._base_url}/app/device/setDeviceStatus"
         payload = {
             "homeId": home_id,


### PR DESCRIPTION
I installed the integration today to set up my HTV245FRF 2-zone hose timer and couldn't get past the login step despite using correct credentials. Wrote a test script to hit the API directly and confirmed the endpoints and auth flow introduced in the modular refactor (`4844b05`) don't match what the API actually expects. Rather than reverting, I rolled the refactor forward while restoring the login logic that actually works.

**Auth/login:**
- Login endpoint was wrong (`/app/login` → `/auth/basic/app/login`), and was missing MD5 password hashing and `deviceId` generation
- Token expiry was hardcoded to 7 days instead of using the server's `tokenExpired` field
- Tokens were stored as ISO strings but the rest of the code expects integer timestamps
- Collapsed the `login()`/`refresh_token()`/`_ensure_auth()` chain into `_login()`/`ensure_logged_in()`/`_token_valid()` with 5-minute early refresh

**API methods:**
- `get_homes()` pointed at `/app/home/list` which doesn't exist — renamed to `list_homes()` hitting `/app/member/appHome/list`
- Removed `get_devices()` (used non-existent `/app/device/list`); `get_devices_by_hid()` is the correct call
- Simplified `get_multiple_device_status()` response conversion to only pull `mid` + `subDeviceStatus`, which is what the coordinator actually expects

**Token restore:**
- The broken refactor stored token expiry as ISO strings; this fix switches back to integer timestamps. The try/except in `restore_tokens()` is cheap insurance in case someone upgrading still has a stale ISO string in their config entry — unlikely since the refactor's login never worked, but costs nothing to guard against.

**Other cleanup:**
- Added debug logging to `_login()` and `list_homes()` for easier troubleshooting (logs request URL, app code, and API responses)
- Login request now explicitly passes `appCode`, `lang`, and `Content-Type` headers which were previously missing
- Tightened type hints (`list` → `list[dict]` on params and return types)
- Standardized error messages to a shorter, consistent pattern (e.g. `"multipleDeviceStatus HTTP {resp.status}"` instead of `"Failed to get device status: {resp.status}"`)
- Minor whitespace cleanup (trailing spaces on blank lines)