### PR TITLE
[codex] Add HACS publishing validation workflows

### DIFF
--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -1,0 +1,19 @@
+name: Hassfest
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  hassfest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Run Hassfest
+        uses: home-assistant/actions/hassfest@master

--- a/.github/workflows/validate-hacs.yml
+++ b/.github/workflows/validate-hacs.yml
@@ -1,0 +1,20 @@
+name: HACS Validation
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  validate-hacs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: HACS validation
+        uses: hacs/action@main
+        with:
+          category: integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.0.28] - 2026-04-17
+
+### 🐛 Bug Fixes
+- **HACS metadata validation** — removed unsupported keys from `hacs.json` so the repository passes the current HACS validation action used for store submission.
+- **Manifest ordering compliance** — sorted `manifest.json` keys to satisfy current Hassfest manifest validation rules.
+
+### 🔧 Internal
+- **Publishing pipeline readiness** — bumped the integration version for the manifest-only packaging update required by the repository’s version enforcement workflow.
+
+---
+
 ## [3.0.27] - 2026-04-17
 
 ### 🐛 Bug Fixes

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Release](https://img.shields.io/github/release/brettmeyerowitz/homeassistant-homgar.svg)](https://github.com/brettmeyerowitz/homeassistant-homgar/releases)
 [![License](https://img.shields.io/github/license/brettmeyerowitz/homeassistant-homgar.svg)](LICENSE)
-[![HACS](https://img.shields.io/badge/HACS-Default-blue.svg)](https://github.com/hacs/integration)
+[![HACS](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/hacs/integration)
 
 Unofficial Home Assistant integration for RainPoint Smart+ devices via the HomGar/RainPoint cloud API.
 

--- a/custom_components/homgar/manifest.json
+++ b/custom_components/homgar/manifest.json
@@ -1,17 +1,17 @@
 {
     "domain": "homgar",
     "name": "HomGar/RainPoint Cloud",
-    "version": "3.0.27",
-    "documentation": "https://github.com/brettmeyerowitz/homeassistant-homgar",
-    "issue_tracker": "https://github.com/brettmeyerowitz/homeassistant-homgar/issues",
-    "requirements": ["paho-mqtt>=1.6.0"],
     "codeowners": [
         "@brettmeyerowitz"
     ],
     "config_flow": true,
-    "iot_class": "cloud_push",
+    "documentation": "https://github.com/brettmeyerowitz/homeassistant-homgar",
     "integration_type": "hub",
+    "iot_class": "cloud_push",
+    "issue_tracker": "https://github.com/brettmeyerowitz/homeassistant-homgar/issues",
     "loggers": [
         "custom_components.homgar"
-    ]
+    ],
+    "requirements": ["paho-mqtt>=1.6.0"],
+    "version": "3.0.28"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,11 +1,5 @@
 {
     "name": "HomGar/RainPoint Cloud",
-    "domains": [
-        "homgar"
-    ],
     "render_readme": true,
-    "homeassistant": "2024.5.0",
-    "iot_class": [
-        "Cloud Polling"
-    ]
+    "homeassistant": "2024.5.0"
 }


### PR DESCRIPTION
## Summary
Prepare the repository for HACS publication by adding the standard validation workflows and fixing the metadata issues those validators surfaced.

## Changes
- add a GitHub Actions workflow for `hacs/action`
- add a GitHub Actions workflow for `home-assistant/actions/hassfest`
- update the README HACS badge to reflect custom-repository status instead of default-store status
- remove unsupported keys from `hacs.json`
- sort `custom_components/homgar/manifest.json` keys for Hassfest compliance
- bump the integration version to `3.0.28`
- add a `3.0.28` changelog entry for the packaging/validation update

## Why
These checks and metadata fixes are needed before submitting the repository to HACS, and the README should not imply the integration is already in the default store.

## Validation
- ran `bash scripts/pre-commit-docker-test.sh`
- latest `Hassfest` run passed on the PR
- latest `HACS Validation` run passed on the PR
