### PR TITLE
Fix rain sensor precision and hub cleanup

### DIFF
--- a/custom_components/homgar/__init__.py
+++ b/custom_components/homgar/__init__.py
@@ -248,6 +248,15 @@ def _assign_devices_to_areas(hass: HomeAssistant, entry: ConfigEntry, coordinato
     """Create HA Areas for each home and assign all homgar devices to them."""
     from homeassistant.helpers import area_registry as ar, device_registry as dr
 
+    def _fallback_hub_name(hub_info: dict) -> str:
+        model = hub_info.get("model")
+        return (
+            hub_info.get("name")
+            or hub_info.get("displayModel")
+            or (model if model and model != "Unknown" else None)
+            or "RainPoint Hub"
+        )
+
     data = coordinator.data
     if not data:
         return
@@ -272,8 +281,16 @@ def _assign_devices_to_areas(hass: HomeAssistant, entry: ConfigEntry, coordinato
             area = area_reg.async_create(home_name)
 
         hub_device = device_reg.async_get_device(identifiers={(DOMAIN, f"rainpoint_hub_{mid}")})
-        if hub_device and hub_device.area_id != area.id:
-            device_reg.async_update_device(hub_device.id, area_id=area.id)
+        if hub_device:
+            update: dict = {}
+            if hub_device.area_id != area.id:
+                update["area_id"] = area.id
+            if not hub_device.name:
+                update["name"] = _fallback_hub_name(hub_info)
+            if not hub_device.model:
+                update["model"] = hub_info.get("model") or hub_info.get("displayModel") or "Unknown"
+            if update:
+                device_reg.async_update_device(hub_device.id, **update)
 
     sensors = data.get("sensors", {})
     group_multi_zone = entry.options.get(CONF_GROUP_MULTI_ZONE_DEVICES, False)

--- a/custom_components/homgar/coordinator.py
+++ b/custom_components/homgar/coordinator.py
@@ -39,6 +39,43 @@ def _extract_state_rssi(raw_state: str | None) -> int | None:
         return None
 
 
+def _is_empty_hub_placeholder(hub: dict) -> bool:
+    """Return True for cloud rows that do not describe a real hub."""
+    metadata_fields = (
+        "model",
+        "displayModel",
+        "mac",
+    )
+    return not any(
+        hub.get(field) and str(hub.get(field)).strip().lower() != "unknown"
+        for field in metadata_fields
+    ) and not hub.get("subDevices")
+
+
+def _hub_metadata_score(hub: dict) -> int:
+    """Prefer complete hub rows over cloud shadow rows."""
+    has_model = any(
+        hub.get(field) and str(hub.get(field)).strip().lower() != "unknown"
+        for field in ("model", "displayModel")
+    )
+    return (
+        (10 if hub.get("subDevices") else 0)
+        + (5 if has_model else 0)
+        + (3 if hub.get("name") else 0)
+        + (2 if hub.get("mac") else 0)
+    )
+
+
+def _hub_identity_keys(hub: dict) -> set[tuple[str, str]]:
+    """Return stable cloud identity keys that can reveal duplicate hub rows."""
+    keys: set[tuple[str, str]] = set()
+    for field in ("deviceName", "iotId"):
+        value = hub.get(field)
+        if value:
+            keys.add((field, str(value)))
+    return keys
+
+
 class HomGarCoordinator(DataUpdateCoordinator):
     """Coordinator for HomGar polling."""
 
@@ -83,11 +120,37 @@ class HomGarCoordinator(DataUpdateCoordinator):
             for hid in homes:
                 devices = await self._client.get_devices_by_hid(hid)
                 _LOGGER.debug("Found %d devices for HID %s: %s", len(devices), hid, [d.get('model', 'unknown') for d in devices])
-                for hub in devices:
+                seen_hub_keys: set[tuple[str, str]] = set()
+                for hub in sorted(devices, key=_hub_metadata_score, reverse=True):
+                    if _is_empty_hub_placeholder(hub):
+                        _LOGGER.debug(
+                            "Skipping empty hub placeholder hid=%s mid=%s",
+                            hid,
+                            hub.get("mid"),
+                        )
+                        continue
+                    identity_keys = _hub_identity_keys(hub)
+                    if identity_keys and seen_hub_keys.intersection(identity_keys):
+                        _LOGGER.debug(
+                            "Skipping duplicate hub shadow hid=%s mid=%s keys=%s",
+                            hid,
+                            hub.get("mid"),
+                            sorted(identity_keys),
+                        )
+                        continue
+                    seen_hub_keys.update(identity_keys)
                     hub_copy = dict(hub)
                     hub_copy["hid"] = hid
                     hub_copy["homeName"] = home_name_by_hid.get(int(hid), "")
                     hub_copy["brand"] = "RainPoint"
+                    hub_model = hub_copy.get("model") or hub_copy.get("displayModel") or "Unknown"
+                    hub_copy["model"] = hub_model
+                    hub_copy["name"] = (
+                        hub_copy.get("name")
+                        or hub_copy.get("displayModel")
+                        or (hub_model if hub_model != "Unknown" else None)
+                        or "RainPoint Hub"
+                    )
                     hubs.append(hub_copy)
 
             # Use efficient multipleDeviceStatus API if available, fall back to individual calls
@@ -278,7 +341,7 @@ class HomGarCoordinator(DataUpdateCoordinator):
                                     "addr": 0,
                                     "home_name": hub.get("homeName"),
                                     "hub_name": hub.get("name", "Hub"),
-                                    "sub_name": hub.get("name", hub_model),
+                                    "sub_name": hub.get("name") or hub_model,
                                     "model": hub_model,
                                     "firmware_version": hub.get("softVer"),
                                     "raw_status": d00,

--- a/custom_components/homgar/decoder.py
+++ b/custom_components/homgar/decoder.py
@@ -560,7 +560,13 @@ def _decode_legacy_fields(leg: dict, unit: str, temp_unit: str,
 
     bat_or_rssi = leg.get("_p1_bat_or_rssi")
     rssi = leg.get("_p1_rssi")
-    if not is_display_hub_v2:
+    # HCS012ARF reports a legacy status slot rather than a useful battery
+    # percentage; the app presents it as full.
+    if model_str.upper() == "HCS012ARF":
+        result["battery_level"] = 100
+        if rssi is not None:
+            result["signal_strength"] = rssi
+    elif not is_display_hub_v2:
         if bat_or_rssi is not None:
             if bat_or_rssi < 0:
                 result["signal_strength"] = bat_or_rssi

--- a/custom_components/homgar/hub_entities.py
+++ b/custom_components/homgar/hub_entities.py
@@ -15,13 +15,27 @@ from .const import DOMAIN
 from .coordinator import HomGarCoordinator
 
 
+def _hub_name(hub_info: dict) -> str:
+    model = hub_info.get("model")
+    return (
+        hub_info.get("name")
+        or hub_info.get("displayModel")
+        or (model if model and model != "Unknown" else None)
+        or "RainPoint Hub"
+    )
+
+
+def _hub_model(hub_info: dict) -> str:
+    return hub_info.get("model") or hub_info.get("displayModel") or "Unknown"
+
+
 class HomGarHubDevice(Entity):
     """Mixin providing device_info for HomGar hub entities."""
 
     def __init__(self, hub_info: dict) -> None:
         self._hub_info = hub_info
         self._attr_unique_id = f"rainpoint_hub_{hub_info['mid']}"
-        self._attr_name = hub_info.get("name", "HomGar Hub")
+        self._attr_name = _hub_name(hub_info)
         self._attr_should_poll = False
 
     @property
@@ -29,12 +43,12 @@ class HomGarHubDevice(Entity):
         mid = self._hub_info["mid"]
         return DeviceInfo(
             identifiers={(DOMAIN, f"rainpoint_hub_{mid}")},
-            name=self._hub_info.get("name", "HomGar Hub"),
+            name=_hub_name(self._hub_info),
             manufacturer="RainPoint",
-            model=self._hub_info.get("model", "Unknown"),
-            sw_version=self._hub_info.get("softVer"),
-            hw_version=self._hub_info.get("hardwareVersion"),
-            serial_number=self._hub_info.get("mac"),
+            model=_hub_model(self._hub_info),
+            sw_version=self._hub_info.get("softVer") or None,
+            hw_version=self._hub_info.get("hardwareVersion") or None,
+            serial_number=self._hub_info.get("mac") or None,
             suggested_area=self._hub_info.get("homeName"),
         )
 
@@ -89,11 +103,11 @@ class HomGarHubDeviceIDSensor(HomGarHubSensorBase):
     def __init__(self, coordinator: HomGarCoordinator, hub_info: dict):
         super().__init__(coordinator, hub_info)
         self._attr_unique_id = f"rainpoint_hub_{hub_info.get('mid', 'unknown')}_device_id"
-        self._attr_name = f"{hub_info.get('name', 'HomGar Hub')} Device ID"
+        self._attr_name = f"{_hub_name(hub_info)} Device ID"
 
     @property
     def native_value(self) -> str | int | None:
-        return self._hub_info.get("hid")
+        return self._hub_info.get("mid")
 
 
 class HomGarHubFirmwareSensor(HomGarHubSensorBase):
@@ -104,7 +118,7 @@ class HomGarHubFirmwareSensor(HomGarHubSensorBase):
     def __init__(self, coordinator: HomGarCoordinator, hub_info: dict):
         super().__init__(coordinator, hub_info)
         self._attr_unique_id = f"rainpoint_hub_{hub_info.get('mid', 'unknown')}_firmware"
-        self._attr_name = f"{hub_info.get('name', 'HomGar Hub')} Firmware Version"
+        self._attr_name = f"{_hub_name(hub_info)} Firmware Version"
 
     @property
     def native_value(self) -> str | None:
@@ -119,7 +133,7 @@ class HomGarHubMACSensor(HomGarHubSensorBase):
     def __init__(self, coordinator: HomGarCoordinator, hub_info: dict):
         super().__init__(coordinator, hub_info)
         self._attr_unique_id = f"rainpoint_hub_{hub_info.get('mid', 'unknown')}_mac"
-        self._attr_name = f"{hub_info.get('name', 'HomGar Hub')} MAC Address"
+        self._attr_name = f"{_hub_name(hub_info)} MAC Address"
 
     @property
     def native_value(self) -> str | None:
@@ -136,7 +150,7 @@ class HomGarHubChannelSelect(CoordinatorEntity, SelectEntity, HomGarHubDevice):
         CoordinatorEntity.__init__(self, coordinator)
         HomGarHubDevice.__init__(self, hub_info)
         self._attr_unique_id = f"rainpoint_hub_{hub_info.get('mid', 'unknown')}_channel"
-        self._attr_name = f"{hub_info.get('name', 'HomGar Hub')} RF Channel"
+        self._attr_name = f"{_hub_name(hub_info)} RF Channel"
         self._attr_options = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16"]
         # Channel 7 from your hub data
         self._attr_current_option = "7"
@@ -167,7 +181,7 @@ class HomGarHubBroadcastSwitch(CoordinatorEntity, SwitchEntity, HomGarHubDevice)
         CoordinatorEntity.__init__(self, coordinator)
         HomGarHubDevice.__init__(self, hub_info)
         self._attr_unique_id = f"rainpoint_hub_{hub_info.get('mid', 'unknown')}_broadcast"
-        self._attr_name = f"{hub_info.get('name', 'HomGar Hub')} Automatic Broadcast"
+        self._attr_name = f"{_hub_name(hub_info)} Automatic Broadcast"
         self._attr_is_on = True  # Default to on
 
     @property

--- a/custom_components/homgar/manifest.json
+++ b/custom_components/homgar/manifest.json
@@ -13,5 +13,5 @@
         "custom_components.homgar"
     ],
     "requirements": ["paho-mqtt>=1.6.0"],
-    "version": "3.0.29"
+    "version": "3.0.30"
 }

--- a/custom_components/homgar/migrate.py
+++ b/custom_components/homgar/migrate.py
@@ -24,11 +24,25 @@ from .decoder import get_valve_ports
 _OLD_HUB_IDENT = re.compile(r"^hub_\d+$")
 _OLD_SENSOR_IDENT = re.compile(r"^\d+_\d+_\d+$")
 _ZONE_DEVICE_IDENT = re.compile(r"^\d+_\d+_zone\d+$")
+_HUB_DEVICE_IDENT = re.compile(r"^rainpoint_hub_(?P<mid>\d+)$")
+_HUB_DIAGNOSTIC_UID = re.compile(
+    r"^rainpoint_hub_(?P<mid>\d+)_(?:device_id|firmware|mac|channel|broadcast)$"
+)
 _PER_ZONE_ENTITY_UID = re.compile(
     r"^rainpoint_(?P<mid>\d+)_(?P<addr>\d+)_(?:(?P<field>.+)_port(?P<sensor_port>\d+)|zone(?P<zone_port>\d+)(?:_duration)?)$"
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _fallback_hub_name(hub_info: dict) -> str:
+    model = hub_info.get("model")
+    return (
+        hub_info.get("name")
+        or hub_info.get("displayModel")
+        or (model if model and model != "Unknown" else None)
+        or "RainPoint Hub"
+    )
 
 
 async def async_migrate_unique_ids(
@@ -116,6 +130,51 @@ async def async_migrate_unique_ids(
                 _LOGGER.warning("HomGar migrate uid failed %s: %s", uid, ex)
 
     device_reg = dr.async_get(hass)
+    known_hub_mids = {str(hub_info.get("mid")) for hub_info in hubs if hub_info.get("mid") is not None}
+
+    # --- Repair devices created from cloud rows with blank name/model strings ---
+    for hub_info in hubs:
+        mid = hub_info.get("mid")
+        if mid is None:
+            continue
+        hub_dev = device_reg.async_get_device(identifiers={(DOMAIN, f"rainpoint_hub_{mid}")})
+        if hub_dev is None:
+            continue
+        update: dict = {}
+        if not hub_dev.name:
+            update["name"] = _fallback_hub_name(hub_info)
+        if not hub_dev.model:
+            update["model"] = hub_info.get("model") or hub_info.get("displayModel") or "Unknown"
+        if update:
+            device_reg.async_update_device(hub_dev.id, **update)
+            _LOGGER.info("HomGar migrate: repaired blank hub device metadata for mid=%s", mid)
+
+    # --- Remove stale placeholder hub devices no longer returned by the cloud ---
+    for device_entry in list(dr.async_entries_for_config_entry(device_reg, entry.entry_id)):
+        idents = {i[1] for i in device_entry.identifiers}
+        hub_mids = {
+            match.group("mid")
+            for ident in idents
+            if (match := _HUB_DEVICE_IDENT.match(ident))
+        }
+        if not hub_mids or hub_mids & known_hub_mids:
+            continue
+
+        attached = er.async_entries_for_device(entity_reg, device_entry.id, include_disabled_entities=True)
+        if not attached:
+            device_reg.async_remove_device(device_entry.id)
+            _LOGGER.info("HomGar migrate: removed stale empty hub device '%s' (%s)", device_entry.name, idents)
+            continue
+
+        if all(
+            entity.unique_id and _HUB_DIAGNOSTIC_UID.match(entity.unique_id)
+            for entity in attached
+        ):
+            for entity in attached:
+                entity_reg.async_remove(entity.entity_id)
+                _LOGGER.info("HomGar migrate: removed stale hub diagnostic entity %s", entity.unique_id)
+            device_reg.async_remove_device(device_entry.id)
+            _LOGGER.info("HomGar migrate: removed stale empty hub device '%s' (%s)", device_entry.name, idents)
 
     # --- Build known old MQTT device identifiers (hid_mid format) from coordinator data ---
     known_old_mqtt_idents: set[str] = set()

--- a/custom_components/homgar/mqtt_client.py
+++ b/custom_components/homgar/mqtt_client.py
@@ -132,6 +132,7 @@ class HomGarMQTTClient:
         self._client_lock = threading.Lock()
         self._shutdown_requested = False
         self._reconnect_thread = None
+        self._log_rate_state: dict[str, tuple[float, int]] = {}
         
         # MQTT diagnostics
         self._messages_received = 0
@@ -160,6 +161,18 @@ class HomGarMQTTClient:
     
     def _label(self) -> str:
         return f" [{self._entry_title}]" if self._entry_title else ""
+
+    def _allow_limited_log(self, key: str, window: int = 300, limit: int = 3) -> bool:
+        """Allow a small number of repeated logs per time window."""
+        now = time.time()
+        window_started, count = self._log_rate_state.get(key, (0.0, 0))
+        if now - window_started > window:
+            self._log_rate_state[key] = (now, 1)
+            return True
+        if count < limit:
+            self._log_rate_state[key] = (window_started, count + 1)
+            return True
+        return False
 
     def connect(self) -> bool:
         """Connect to MQTT broker."""
@@ -219,7 +232,7 @@ class HomGarMQTTClient:
             self._client.connect(self._mqtt_host, self._mqtt_port, 60)
             self._client.loop_start()
     
-    def _wait_for_connection(self) -> bool:
+    def _wait_for_connection(self, log_timeout: bool = True) -> bool:
         """Wait for MQTT connection to establish."""
         for i in range(20):
             if self._connected:
@@ -227,7 +240,8 @@ class HomGarMQTTClient:
                     "HomGar MQTT%s connection established after %d attempts", self._label(), i + 1)
                 return True
             time.sleep(0.5)
-        _LOGGER.error("HomGar MQTT%s connection timeout after 10 seconds", self._label())
+        if log_timeout:
+            _LOGGER.error("HomGar MQTT%s connection timeout after 10 seconds", self._label())
         return False
     
     def _on_connect(self, client, userdata, flags, rc):
@@ -248,7 +262,18 @@ class HomGarMQTTClient:
             _LOGGER.info("HomGar MQTT%s disconnected cleanly (shutdown requested)", self._label())
             return
         
-        _LOGGER.warning("HomGar MQTT%s disconnected unexpectedly (rc=%s) - will attempt reconnect", self._label(), rc)
+        if self._allow_limited_log("disconnect"):
+            _LOGGER.warning(
+                "HomGar MQTT%s disconnected unexpectedly (rc=%s) - will attempt reconnect",
+                self._label(),
+                rc,
+            )
+        else:
+            _LOGGER.debug(
+                "HomGar MQTT%s disconnected unexpectedly (rc=%s) - reconnect already pending",
+                self._label(),
+                rc,
+            )
         if rc != 0:
             self._start_reconnect_thread()
     
@@ -270,20 +295,34 @@ class HomGarMQTTClient:
             if self._shutdown_requested:
                 _LOGGER.info("HomGar MQTT reconnect cancelled (shutdown requested)")
                 return
-            
-            delay = min(30 * attempt, 300)
-            _LOGGER.info("HomGar MQTT%s reconnect attempt %d in %d seconds", self._label(), attempt, delay)
+
+            delay = min(30 * (2 ** (attempt - 1)), 300)
+            if self._allow_limited_log("reconnect_attempt"):
+                _LOGGER.info(
+                    "HomGar MQTT%s reconnect attempt %d in %d seconds",
+                    self._label(),
+                    attempt,
+                    delay,
+                )
             time.sleep(delay)
-            
+
             try:
                 self._connect_client()
-                if self._wait_for_connection():
+                if self._wait_for_connection(log_timeout=False):
                     _LOGGER.info("HomGar MQTT%s reconnected successfully on attempt %d", self._label(), attempt)
                     return
                 raise RuntimeError("MQTT reconnect timed out")
             except Exception as e:
-                _LOGGER.error("HomGar MQTT%s reconnect attempt %d failed: %s", self._label(), attempt, e)
-        
+                if attempt < 5:
+                    if self._allow_limited_log("reconnect_failure"):
+                        _LOGGER.warning(
+                            "HomGar MQTT%s reconnect attempt %d failed: %s",
+                            self._label(),
+                            attempt,
+                            e,
+                        )
+                else:
+                    _LOGGER.error("HomGar MQTT%s reconnect attempt %d failed: %s", self._label(), attempt, e)
         _LOGGER.error("HomGar MQTT%s reconnect exhausted after 5 attempts", self._label())
     
     def _on_message(self, client, userdata, msg):

--- a/custom_components/homgar/sensor.py
+++ b/custom_components/homgar/sensor.py
@@ -299,6 +299,8 @@ class HomGarGenericSensor(HomGarSensorBase):
                 self._attr_entity_category = sdef.entity_category
             if sdef.icon:
                 self._attr_icon = sdef.icon
+            if sdef.suggested_display_precision is not None:
+                self._attr_suggested_display_precision = sdef.suggested_display_precision
 
         sub_name = sensor_info.get("sub_name") or "Sensor"
         label = (sdef.name if sdef and sdef.name else field_name.replace("_", " ").title())

--- a/custom_components/homgar/sensor_defs.py
+++ b/custom_components/homgar/sensor_defs.py
@@ -42,6 +42,7 @@ class SensorDef:
     entity_category: EntityCategory | None = None
     icon: str | None = None
     name: str | None = None
+    suggested_display_precision: int | None = None
 
 
 FIELD_SENSOR_MAP: dict[str, SensorDef | None] = {
@@ -130,6 +131,7 @@ FIELD_SENSOR_MAP: dict[str, SensorDef | None] = {
         unit=UnitOfLength.MILLIMETERS,
         state_class=SensorStateClass.TOTAL_INCREASING,
         name="Rain Total",
+        suggested_display_precision=2,
     ),
     "precipitation_1h": SensorDef(
         device_class=SensorDeviceClass.PRECIPITATION,
@@ -137,6 +139,7 @@ FIELD_SENSOR_MAP: dict[str, SensorDef | None] = {
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:weather-rainy",
         name="Rain Last Hour",
+        suggested_display_precision=2,
     ),
     "precipitation_24h": SensorDef(
         device_class=SensorDeviceClass.PRECIPITATION,
@@ -144,6 +147,7 @@ FIELD_SENSOR_MAP: dict[str, SensorDef | None] = {
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:weather-rainy",
         name="Rain Last 24h",
+        suggested_display_precision=2,
     ),
     "precipitation_7d": SensorDef(
         device_class=SensorDeviceClass.PRECIPITATION,
@@ -151,6 +155,7 @@ FIELD_SENSOR_MAP: dict[str, SensorDef | None] = {
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:weather-rainy",
         name="Rain Last 7 Days",
+        suggested_display_precision=2,
     ),
 
     # --- Diagnostics ---

--- a/scripts/test_decoders.py
+++ b/scripts/test_decoders.py
@@ -227,6 +227,10 @@ check("no error",          "error" not in r)
 check("has rain fields",   any(k in r for k in ("precipitation_total", "precipitation_1h", "precipitation_24h")))
 check("battery present",   r.get("battery_level") is not None)
 check("signal present",    r.get("signal_strength") is not None)
+dean_rain = decode_payload("HCS012ARF", "1,0,1;R=100(0/70/100)")
+check("Dean sample total=10.0mm", dean_rain.get("precipitation_total") == 10.0, str(dean_rain.get("precipitation_total")))
+check("Dean sample 24h=7.0mm", dean_rain.get("precipitation_24h") == 7.0, str(dean_rain.get("precipitation_24h")))
+check("Dean sample 7d=10.0mm", dean_rain.get("precipitation_7d") == 10.0, str(dean_rain.get("precipitation_7d")))
 
 
 # ── Temperature conversion regression (issue #21 root cause) ─────────────────


### PR DESCRIPTION
## Summary
- reduce MQTT reconnect log spam with rate-limited logs and exponential backoff
- fix HCS012ARF rain gauge battery reporting while preserving RSSI
- add display precision for precipitation so small inch values do not round to `0 in`
- filter and clean up low-information shadow hub devices from the HA device registry
- bump integration version to 3.0.30

## Validation
- `PYTHONPATH=. .venv/bin/python scripts/test_decoders.py`
- `.venv/bin/python tests/run_mqtt_routing_tests.py`
- `python3 -m compileall -q custom_components/homgar scripts/test_decoders.py`
- `bash scripts/pre-commit-docker-test.sh`
- commit hook Docker pre-commit suite

## Notes
- Dean's HCS012ARF sample `1,0,1;R=100(0/70/100)` now has explicit regression coverage.
- Confirmed in `ha-test` that the shadow hub device is removed while the real hub/display devices remain.
