### PR TITLE
Fix HTV157B valve control endpoint

### DIFF
--- a/custom_components/homgar/decoder.py
+++ b/custom_components/homgar/decoder.py
@@ -97,8 +97,17 @@ def get_valve_ports(model: str) -> list[int]:
     return []
 
 
+DP_VALVE_CONTROL_MODELS: frozenset[str] = frozenset({
+    # HTV157B exposes CTL_WATER rather than CTL_BT_WATER in product metadata,
+    # but the legacy controlWorkMode endpoint returns code=3 for this model.
+    "HTV157B",
+})
+
+
 def uses_ble_valve_control(model: str) -> bool:
-    """Return True when the model exposes BLE valve control datapoints."""
+    """Return True when the model should use the DP valve control endpoint."""
+    if model.upper() in DP_VALVE_CONTROL_MODELS:
+        return True
     info = get_model_info(model)
     if not info:
         return False

--- a/custom_components/homgar/manifest.json
+++ b/custom_components/homgar/manifest.json
@@ -13,5 +13,5 @@
         "custom_components.homgar"
     ],
     "requirements": ["paho-mqtt>=1.6.0"],
-    "version": "3.0.31"
+    "version": "3.0.32"
 }

--- a/tests/run_ble_valve_model_tests.py
+++ b/tests/run_ble_valve_model_tests.py
@@ -91,6 +91,10 @@ def main() -> int:
         decoder.uses_ble_valve_control("HTV224B") is True,
     )
     check(
+        "HTV157B uses DP valve control override",
+        decoder.uses_ble_valve_control("HTV157B") is True,
+    )
+    check(
         "HTV203FRF is not detected as BLE-backed",
         decoder.uses_ble_valve_control("HTV203FRF") is False,
     )


### PR DESCRIPTION
## Summary
- route HTV157B valve commands through the DP control endpoint used by BLE-style valves
- keep the override model-specific to avoid changing RF-style HTV models without evidence
- add regression coverage for HTV157B control-path selection
- bump integration version to 3.0.32

## Context
Issue #49 reports HTV157B status payloads decoding correctly, but valve activation failing with `controlWorkMode failed: code=3 msg=`. This matches the same endpoint-selection class as #42, where HTV210B needed `controlWorkModeDP` rather than legacy `controlWorkMode`.

## Validation
- `python3 -m compileall -q custom_components/homgar`
- `.venv/bin/python tests/run_ble_valve_model_tests.py`
- `PYTHONPATH=. .venv/bin/python scripts/test_decoders.py`
- `bash scripts/pre-commit-docker-test.sh`
- commit hook Docker pre-commit suite

Refs #49.
