### PR TITLE
Document RainPoint-TY compatibility boundary

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,6 +10,8 @@ body:
         
         Please provide as much detail as possible to help us identify and fix the issue.
 
+        **Compatibility note:** This integration supports HomGar / RainPoint Smart+ / RainPoint Home H-series devices. RainPoint-TY / Tuya T-series devices are not supported; login or discovery failures for RainPoint-TY accounts are expected and should not be filed as integration bugs.
+
         **Latest released integration version:** `3.0.24`
         
         Please update to the latest release and restart Home Assistant before opening a bug report.
@@ -162,6 +164,8 @@ body:
         - label: I have provided steps to reproduce the issue
           required: true
         - label: I have included the integration version
+          required: true
+        - label: I am not using a RainPoint-TY / Tuya T-series device or account
           required: true
         - label: For sensor value bugs, I have attached screenshots from the RainPoint/HomGar app showing the correct values
           required: false

--- a/.github/ISSUE_TEMPLATE/device_support.yml
+++ b/.github/ISSUE_TEMPLATE/device_support.yml
@@ -14,6 +14,8 @@ body:
         
         The more payload+screenshot pairs you provide (in different states), the faster and more accurate the implementation will be.
 
+        **Compatibility note:** This integration supports HomGar / RainPoint Smart+ / RainPoint Home H-series devices. RainPoint-TY / Tuya T-series devices are not supported by this integration. If your model starts with `T` or only pairs with the RainPoint-TY app, please try a Tuya-compatible Home Assistant integration instead.
+
         **Latest released integration version:** `3.0.24`
         
         Please update to the latest release and restart Home Assistant before opening a new device support request.
@@ -186,4 +188,6 @@ body:
         - label: I have described what the device should display in Home Assistant
           required: true
         - label: I have checked that this device is not already supported
+          required: true
+        - label: My device is not a RainPoint-TY / Tuya T-series device
           required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -9,6 +9,8 @@ body:
         ## Thanks for suggesting a feature!
         
         Please describe the feature you'd like to see added to the integration.
+
+        **Compatibility note:** This integration supports HomGar / RainPoint Smart+ / RainPoint Home H-series devices. RainPoint-TY / Tuya T-series devices are outside the scope of this integration because RainPoint documents them as a separate ecosystem with different hardware protocols and incompatible hubs.
   
   - type: textarea
     id: feature_description

--- a/README.md
+++ b/README.md
@@ -119,9 +119,13 @@ Whether you're troubleshooting a device, requesting a new model, or just want to
 
 For reproducible bugs and new device support, please open a GitHub issue rather than a discussion so logs, device details, and payload samples are captured in the right format.
 
-**HomGar** is the mobile app and cloud platform. **RainPoint** is the hardware manufacturer. All device models (HCS\*, HTV\*, HWG\*, etc.) are RainPoint hardware accessible via either mobile app.
+## Compatibility
 
-This integration supports the **HomGar** app and **RainPoint Smart+** app cloud accounts only. The legacy **RainPoint-TY** app appears to use the Tuya platform and is not supported by this integration.
+**HomGar** is the mobile app and cloud platform. **RainPoint** is the hardware manufacturer. This integration supports the **HomGar** app and **RainPoint Smart+ / RainPoint Home** app cloud accounts for RainPoint **H-series / Home ecosystem** devices, such as HCS\*, HTV\*, and HWG\* models.
+
+The **RainPoint-TY / Tuya** app and **T-series / Tuya ecosystem** devices are not supported by this integration. RainPoint's own compatibility guide explains that Tuya devices use T-series model numbers, Home devices use H-series model numbers, and the two ecosystems use different hardware protocols and incompatible hubs: [RainPoint Smart Irrigation Timer Guide: Tuya vs. Home APP](https://www.rainpointonline.com/blogs/lawn-garden/rainpoint-smart-irrigation-timer-guide-how-to-distinguish-between-tuya-vs-home-app-compatible-devices).
+
+Examples of unsupported Tuya/T-series models include TTV\*, TTP\*, TWG\*, and TCS\* devices. These cannot be added by selecting **RainPoint Smart+** in this integration; they need a Tuya-compatible Home Assistant integration or a separate RainPoint-TY/Tuya integration.
 
 ---
 
@@ -165,7 +169,7 @@ If nothing appears, check logs under:
 3. Enter your account credentials (email and country code)
 4. Select which homes to include
 
-The **RainPoint-TY** app is not the same as **RainPoint Smart+**. If your device is paired only in RainPoint-TY, this integration will not be able to authenticate or discover it.
+The **RainPoint-TY** app is not the same as **RainPoint Smart+ / RainPoint Home**. If your device is paired only in RainPoint-TY, or the model number starts with `T`, this integration will not be able to authenticate or discover it.
 
 > **⚠️ API session conflict:** Logging in via this integration will log you out of the mobile app. The API only supports one active session per account. **Create a dedicated API account** (invite it as a home member) to avoid this — see [Multiple Accounts](#multiple-accounts--sites) below.
 
@@ -310,7 +314,7 @@ If your device model isn't in the supported list, the integration will log a war
 
 - **Logged out of mobile app**: Use a dedicated API account (see above)
 - **No devices found**: Ensure you selected the correct app type (HomGar vs RainPoint) — the two apps use separate account systems
-- **RainPoint-TY account fails to log in**: RainPoint-TY appears to be a legacy Tuya app and is not supported; use a HomGar or RainPoint Smart+ account with compatible devices
+- **RainPoint-TY account fails to log in**: RainPoint-TY/Tuya accounts and T-series devices are not supported; use a HomGar or RainPoint Smart+ / RainPoint Home account with compatible H-series devices
 - **Entities unavailable after upgrade**: Follow the clean install steps in [Upgrading from v2.x](#upgrading-from-v2x)
 - **Wrong app type configured**: Go to the integration → three-dot menu → **Reconfigure**
 


### PR DESCRIPTION
## Summary

- Clarifies that this integration supports HomGar / RainPoint Smart+ / RainPoint Home H-series devices.
- Documents that RainPoint-TY / Tuya T-series devices are outside the integration scope.
- Adds compatibility warnings and checklist items to GitHub issue templates.

## Context

Issue #52 requested RainPoint-TY cloud support for a TTP106W pump. RainPoint's own compatibility guide describes T-series/Tuya devices and H-series/Home devices as separate ecosystems with different hardware protocols and incompatible hubs.

## Validation

Docs/templates only. No runtime tests run.
