### PR TITLE
Link RainPoint compatibility wiki

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,7 +10,7 @@ body:
         
         Please provide as much detail as possible to help us identify and fix the issue.
 
-        **Compatibility note:** This integration supports HomGar / RainPoint Smart+ / RainPoint Home H-series devices. RainPoint-TY / Tuya T-series devices are not supported; login or discovery failures for RainPoint-TY accounts are expected and should not be filed as integration bugs.
+        **Compatibility note:** This integration supports HomGar / RainPoint Smart+ / RainPoint Home H-series devices. RainPoint-TY / Tuya T-series devices are not supported; login or discovery failures for RainPoint-TY accounts are expected and should not be filed as integration bugs. See the wiki compatibility guide: https://github.com/brettmeyerowitz/homeassistant-homgar/wiki/RainPoint-App-and-Device-Compatibility
 
         **Latest released integration version:** `3.0.24`
         

--- a/.github/ISSUE_TEMPLATE/device_support.yml
+++ b/.github/ISSUE_TEMPLATE/device_support.yml
@@ -14,7 +14,7 @@ body:
         
         The more payload+screenshot pairs you provide (in different states), the faster and more accurate the implementation will be.
 
-        **Compatibility note:** This integration supports HomGar / RainPoint Smart+ / RainPoint Home H-series devices. RainPoint-TY / Tuya T-series devices are not supported by this integration. If your model starts with `T` or only pairs with the RainPoint-TY app, please try a Tuya-compatible Home Assistant integration instead.
+        **Compatibility note:** This integration supports HomGar / RainPoint Smart+ / RainPoint Home H-series devices. RainPoint-TY / Tuya T-series devices are not supported by this integration. If your model starts with `T` or only pairs with the RainPoint-TY app, please try a Tuya-compatible Home Assistant integration instead. See the wiki compatibility guide: https://github.com/brettmeyerowitz/homeassistant-homgar/wiki/RainPoint-App-and-Device-Compatibility
 
         **Latest released integration version:** `3.0.24`
         

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -10,7 +10,7 @@ body:
         
         Please describe the feature you'd like to see added to the integration.
 
-        **Compatibility note:** This integration supports HomGar / RainPoint Smart+ / RainPoint Home H-series devices. RainPoint-TY / Tuya T-series devices are outside the scope of this integration because RainPoint documents them as a separate ecosystem with different hardware protocols and incompatible hubs.
+        **Compatibility note:** This integration supports HomGar / RainPoint Smart+ / RainPoint Home H-series devices. RainPoint-TY / Tuya T-series devices are outside the scope of this integration because RainPoint documents them as a separate ecosystem with different hardware protocols and incompatible hubs. See the wiki compatibility guide: https://github.com/brettmeyerowitz/homeassistant-homgar/wiki/RainPoint-App-and-Device-Compatibility
   
   - type: textarea
     id: feature_description

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ The **RainPoint-TY / Tuya** app and **T-series / Tuya ecosystem** devices are no
 
 Examples of unsupported Tuya/T-series models include TTV\*, TTP\*, TWG\*, and TCS\* devices. These cannot be added by selecting **RainPoint Smart+** in this integration; they need a Tuya-compatible Home Assistant integration or a separate RainPoint-TY/Tuya integration.
 
+See the wiki for a longer explanation: [RainPoint App and Device Compatibility](https://github.com/brettmeyerowitz/homeassistant-homgar/wiki/RainPoint-App-and-Device-Compatibility).
+
 ---
 
 ## Quick sanity check


### PR DESCRIPTION
## Summary

- Links the README compatibility section to the new wiki compatibility page.
- Links the bug, device support, and feature request templates to the same wiki page.

## Validation

Docs/templates only. No runtime tests run.
