### PR TITLE
Release 3.0.33 hub diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.0.33] - 2026-05-13
+
+### 🔧 Diagnostics
+- **Hub raw status diagnostics** — added disabled-by-default `Raw Status`, `Last MQTT Payload`, and `Last MQTT Summary` entities for hub/main WiFi devices so unsupported main-device models can expose troubleshooting payloads even before a decoded child sensor exists.
+- **MQTT fallback capture** — MQTT payloads are now retained at the hub level when a message cannot be routed to an existing device sensor key, making it possible to debug newly discovered WiFi models such as `HTP159W`.
+
+### 🧪 Tests
+- **MQTT routing regression coverage** — added checks that hub-level MQTT diagnostics are stored and entity updates are emitted even when the device-specific sensor is missing.
+
+---
+
 ## [3.0.29] - 2026-04-24
 
 ### 🐛 Bug Fixes

--- a/custom_components/homgar/coordinator.py
+++ b/custom_components/homgar/coordinator.py
@@ -386,7 +386,8 @@ class HomGarCoordinator(DataUpdateCoordinator):
             for hub in hubs:
                 hub_key = f"rainpoint_hub_{hub.get('mid')}"
                 if hub.get("productKey") and hub.get("deviceName"):
-                    self._mqtt_diagnostics[hub_key] = diagnostics
+                    existing = self._mqtt_diagnostics.get(hub_key, {})
+                    self._mqtt_diagnostics[hub_key] = {**existing, **diagnostics}
                 else:
                     # Remove diagnostics for hubs without MQTT
                     self._mqtt_diagnostics.pop(hub_key, None)

--- a/custom_components/homgar/coordinator_mqtt.py
+++ b/custom_components/homgar/coordinator_mqtt.py
@@ -58,6 +58,7 @@ async def handle_mqtt_update(coordinator: "HomGarCoordinator", data: dict) -> No
 
     matched_mid = str(target_hub.get("mid"))
     hub_name = target_hub.get("name", "Hub")
+    now_iso = datetime.now(timezone.utc).isoformat()
 
     _LOGGER.debug(
         "HomGar MQTT: Found hub mid=%s name=%s model=%s sub_devices=%d",
@@ -73,6 +74,19 @@ async def handle_mqtt_update(coordinator: "HomGarCoordinator", data: dict) -> No
     except (ValueError, IndexError):
         _LOGGER.warning("HomGar MQTT: Invalid device_key format: %s", device_key)
         return
+
+    hub_diag_key = f"rainpoint_hub_{matched_mid}"
+    hub_diag = dict(coordinator._mqtt_diagnostics.get(hub_diag_key) or {})
+    hub_diag.update(
+        {
+            "raw_payload": payload,
+            "friendly_summary": f"{device_key}: payload received",
+            "last_received": now_iso,
+            "device_key": device_key,
+            "hub_mid": matched_mid,
+        }
+    )
+    coordinator._mqtt_diagnostics[hub_diag_key] = hub_diag
     
     _LOGGER.debug(
         "HomGar MQTT: Processing update for hub_mid=%s name=%s addr=%d model=%s",
@@ -122,6 +136,7 @@ async def handle_mqtt_update(coordinator: "HomGarCoordinator", data: dict) -> No
                 pass
         if "error" in decoded:
             _LOGGER.debug("HomGar MQTT: No decoder for model=%s (sub_model=%s)", model, sub_model)
+            coordinator.async_set_updated_data(coordinator.data)
             return
         top_fields = [k for k in decoded if not k.startswith("port_") and k not in ("port_number", "dp_flag")]
         _LOGGER.debug(
@@ -139,8 +154,6 @@ async def handle_mqtt_update(coordinator: "HomGarCoordinator", data: dict) -> No
         decoded_sensors = coordinator.data.get("sensors", {})
         
         if sensor_key in decoded_sensors:
-            now_iso = datetime.now(timezone.utc).isoformat()
-
             # Determine status message based on decoded fields (v3 field names)
             watering_ports = [
                 p
@@ -272,6 +285,7 @@ async def handle_mqtt_update(coordinator: "HomGarCoordinator", data: dict) -> No
                 sub_name or model,
                 available_keys
             )
+            coordinator.async_set_updated_data(coordinator.data)
     
     except Exception as e:
         _LOGGER.error("HomGar MQTT: Failed to decode payload: %s", e, exc_info=True)

--- a/custom_components/homgar/hub_entities.py
+++ b/custom_components/homgar/hub_entities.py
@@ -29,6 +29,17 @@ def _hub_model(hub_info: dict) -> str:
     return hub_info.get("model") or hub_info.get("displayModel") or "Unknown"
 
 
+def _hub_status_payload(coordinator: HomGarCoordinator, mid: int | str) -> dict:
+    status_by_mid = coordinator.data.get("status", {}) if coordinator.data else {}
+    return status_by_mid.get(mid) or status_by_mid.get(str(mid)) or {}
+
+
+def _hub_status_entries(coordinator: HomGarCoordinator, mid: int | str) -> list[dict]:
+    status = _hub_status_payload(coordinator, mid)
+    entries = status.get("subDeviceStatus", [])
+    return entries if isinstance(entries, list) else []
+
+
 class HomGarHubDevice(Entity):
     """Mixin providing device_info for HomGar hub entities."""
 
@@ -138,6 +149,134 @@ class HomGarHubMACSensor(HomGarHubSensorBase):
     @property
     def native_value(self) -> str | None:
         return self._hub_info.get("mac")
+
+
+class HomGarHubRawStatusSensor(HomGarHubSensorBase):
+    """Raw cloud status payload for a hub/main WiFi device."""
+
+    _attr_icon = "mdi:code-braces"
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, coordinator: HomGarCoordinator, hub_info: dict):
+        super().__init__(coordinator, hub_info)
+        self._attr_unique_id = f"rainpoint_hub_{hub_info.get('mid', 'unknown')}_raw_status"
+        self._attr_name = f"{_hub_name(hub_info)} Raw Status"
+
+    @property
+    def native_value(self) -> str | None:
+        entries = _hub_status_entries(self.coordinator, self._hub_info.get("mid"))
+        preferred_ids = ("D00", "D0")
+        for preferred_id in preferred_ids:
+            value = next(
+                (
+                    entry.get("value")
+                    for entry in entries
+                    if entry.get("id") == preferred_id and entry.get("value")
+                ),
+                None,
+            )
+            if value is not None:
+                return str(value)
+        for entry in entries:
+            status_id = str(entry.get("id", ""))
+            value = entry.get("value")
+            if status_id.startswith("D") and value:
+                return str(value)
+        return None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        entries = _hub_status_entries(self.coordinator, self._hub_info.get("mid"))
+        raw_status_by_id = {
+            str(entry.get("id")): entry.get("value")
+            for entry in entries
+            if entry.get("id") is not None and entry.get("value") is not None
+        }
+        return {
+            "mid": self._hub_info.get("mid"),
+            "model": _hub_model(self._hub_info),
+            "status_ids": [entry.get("id") for entry in entries if entry.get("id")],
+            "raw_status_by_id": raw_status_by_id,
+            "status_payload": _hub_status_payload(self.coordinator, self._hub_info.get("mid")),
+        }
+
+
+class HomGarHubMqttRawPayloadSensor(HomGarHubSensorBase):
+    """Last raw MQTT payload seen for a hub/main WiFi device."""
+
+    _attr_icon = "mdi:antenna"
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, coordinator: HomGarCoordinator, hub_info: dict):
+        super().__init__(coordinator, hub_info)
+        self._attr_unique_id = f"rainpoint_hub_{hub_info.get('mid', 'unknown')}_mqtt_raw"
+        self._attr_name = f"{_hub_name(hub_info)} Last MQTT Payload"
+
+    @property
+    def available(self) -> bool:
+        diag = self.coordinator._mqtt_diagnostics.get(self._diag_key)
+        return bool(diag and diag.get("raw_payload"))
+
+    @property
+    def _diag_key(self) -> str:
+        return f"rainpoint_hub_{self._hub_info.get('mid')}"
+
+    @property
+    def native_value(self) -> str | None:
+        diag = self.coordinator._mqtt_diagnostics.get(self._diag_key) or {}
+        payload = diag.get("raw_payload")
+        return str(payload) if payload is not None else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        diag = self.coordinator._mqtt_diagnostics.get(self._diag_key) or {}
+        return {
+            "last_received": diag.get("last_received"),
+            "device_key": diag.get("device_key"),
+            "hub_mid": diag.get("hub_mid"),
+            "connected": diag.get("connected"),
+            "messages_received": diag.get("messages_received"),
+            "last_message_age_seconds": diag.get("last_message_age_seconds"),
+        }
+
+
+class HomGarHubMqttFriendlySensor(HomGarHubSensorBase):
+    """Last MQTT message summary for a hub/main WiFi device."""
+
+    _attr_icon = "mdi:message-text"
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, coordinator: HomGarCoordinator, hub_info: dict):
+        super().__init__(coordinator, hub_info)
+        self._attr_unique_id = f"rainpoint_hub_{hub_info.get('mid', 'unknown')}_mqtt_friendly"
+        self._attr_name = f"{_hub_name(hub_info)} Last MQTT Summary"
+
+    @property
+    def available(self) -> bool:
+        diag = self.coordinator._mqtt_diagnostics.get(self._diag_key)
+        return bool(diag and diag.get("friendly_summary"))
+
+    @property
+    def _diag_key(self) -> str:
+        return f"rainpoint_hub_{self._hub_info.get('mid')}"
+
+    @property
+    def native_value(self) -> str | None:
+        diag = self.coordinator._mqtt_diagnostics.get(self._diag_key) or {}
+        summary = diag.get("friendly_summary")
+        return str(summary) if summary is not None else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        diag = self.coordinator._mqtt_diagnostics.get(self._diag_key) or {}
+        return {
+            "last_received": diag.get("last_received"),
+            "device_key": diag.get("device_key"),
+            "hub_mid": diag.get("hub_mid"),
+            "connected": diag.get("connected"),
+            "messages_received": diag.get("messages_received"),
+            "last_message_age_seconds": diag.get("last_message_age_seconds"),
+        }
 
 
 class HomGarHubChannelSelect(CoordinatorEntity, SelectEntity, HomGarHubDevice):

--- a/custom_components/homgar/manifest.json
+++ b/custom_components/homgar/manifest.json
@@ -13,5 +13,5 @@
         "custom_components.homgar"
     ],
     "requirements": ["paho-mqtt>=1.6.0"],
-    "version": "3.0.32"
+    "version": "3.0.33"
 }

--- a/custom_components/homgar/sensor.py
+++ b/custom_components/homgar/sensor.py
@@ -38,6 +38,9 @@ from .hub_entities import (
     HomGarHubDeviceIDSensor,
     HomGarHubFirmwareSensor,
     HomGarHubMACSensor,
+    HomGarHubMqttFriendlySensor,
+    HomGarHubMqttRawPayloadSensor,
+    HomGarHubRawStatusSensor,
     HomGarHubChannelSelect,
     HomGarHubBroadcastSwitch,
 )
@@ -100,6 +103,9 @@ async def async_setup_entry(
         entities.append(HomGarHubDeviceIDSensor(coordinator, hub_info))
         entities.append(HomGarHubFirmwareSensor(coordinator, hub_info))
         entities.append(HomGarHubMACSensor(coordinator, hub_info))
+        entities.append(HomGarHubRawStatusSensor(coordinator, hub_info))
+        entities.append(HomGarHubMqttRawPayloadSensor(coordinator, hub_info))
+        entities.append(HomGarHubMqttFriendlySensor(coordinator, hub_info))
         entities.append(HomGarHubChannelSelect(coordinator, hub_info))
         entities.append(HomGarHubBroadcastSwitch(coordinator, hub_info))
 

--- a/tests/run_mqtt_routing_tests.py
+++ b/tests/run_mqtt_routing_tests.py
@@ -101,7 +101,7 @@ class FakeCoordinator:
         self.data = data
 
 
-async def _run_case() -> tuple[bool, dict, dict]:
+async def _run_case() -> tuple[bool, dict, dict, dict]:
     coordinator = FakeCoordinator()
     await coordinator_mqtt.handle_mqtt_update(
         coordinator,
@@ -114,7 +114,8 @@ async def _run_case() -> tuple[bool, dict, dict]:
     )
     sensor = coordinator.data["sensors"]["39929_0"]
     diag = coordinator._mqtt_diagnostics.get("39929_0", {})
-    return coordinator.updated, sensor, diag
+    hub_diag = coordinator._mqtt_diagnostics.get("rainpoint_hub_39929", {})
+    return coordinator.updated, sensor, diag, hub_diag
 
 
 async def _run_no_change_case() -> tuple[bool, dict, dict]:
@@ -145,13 +146,42 @@ async def _run_no_change_case() -> tuple[bool, dict, dict]:
     return coordinator.updated, sensor, diag
 
 
+async def _run_missing_sensor_case() -> tuple[bool, dict]:
+    coordinator = FakeCoordinator()
+    coordinator.data["sensors"] = {}
+    await coordinator_mqtt.handle_mqtt_update(
+        coordinator,
+        {
+            "hub_mid": "139929",
+            "hub_mid_candidates": ["139929", "39929"],
+            "device_key": "D00",
+            "payload": "10#108800AF00000000B700204200D800F700000000F9FF00",
+        },
+    )
+    hub_diag = coordinator._mqtt_diagnostics.get("rainpoint_hub_39929", {})
+    return coordinator.updated, hub_diag
+
+
 def main() -> int:
     print("\n🧪 MQTT routing regression tests")
-    updated, sensor, diag = asyncio.run(_run_case())
+    updated, sensor, diag, hub_diag = asyncio.run(_run_case())
     check("routes D00 update using MID candidate alias", updated)
     check("updates hub-as-device sensor key", sensor["raw_status"]["value"].startswith("10#1088"), repr(sensor))
     check("decoded idle zone 1 state", sensor["data"].get("port_1", {}).get("is_watering") is False, repr(sensor["data"]))
     check("records mqtt diagnostics", bool(diag), repr(diag))
+    check(
+        "records hub-level mqtt diagnostics",
+        hub_diag.get("raw_payload", "").startswith("10#1088"),
+        repr(hub_diag),
+    )
+
+    missing_sensor_updated, missing_sensor_hub_diag = asyncio.run(_run_missing_sensor_case())
+    check("notifies entities when only hub-level mqtt diagnostics update", missing_sensor_updated)
+    check(
+        "records hub-level mqtt diagnostics without sensor key",
+        missing_sensor_hub_diag.get("raw_payload", "").startswith("10#1088"),
+        repr(missing_sensor_hub_diag),
+    )
 
     hic = FakeCoordinator()
     hic.data = {


### PR DESCRIPTION
## Summary

- Add disabled-by-default hub-level raw status and MQTT diagnostic sensors for hub/main WiFi devices.
- Preserve MQTT payload diagnostics at the hub level even when an incoming message cannot be routed to a decoded device sensor.
- Bump the integration to v3.0.33 and document the release notes.

## Why

New WiFi main-device models such as HTP159W can currently fail before a device-specific sensor is created, which also prevents the existing raw payload diagnostics from appearing. These hub-level diagnostics give users a way to capture REST/MQTT payloads needed for device support.

## Validation

- `python3 tests/run_mqtt_routing_tests.py`
- `python3 -m compileall custom_components/homgar/hub_entities.py custom_components/homgar/sensor.py custom_components/homgar/coordinator.py custom_components/homgar/coordinator_mqtt.py`
- `bash scripts/pre-commit-docker-test.sh`
