### PR TITLE
Add HTP159W WiFi valve support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.0.34] - 2026-05-13
+
+### 🐛 Bug Fixes
+- **HTP159W WiFi valve discovery** — fixed `HTP159W` main WiFi valve/tap timer support by recognizing raw device payloads delivered in the cloud `state` field. These devices do not expose a child `subDevice[]` or a `D00`/`D0` status entry, so they were previously visible only as a hub diagnostic device with `Raw Status` stuck at `unknown`.
+- **HTP159W realtime MQTT routing** — MQTT payloads carried in `state` are now routed to the hub-as-device sensor key (`addr=0`) while normal hub RSSI state strings such as `0,-68` are still ignored as non-device payloads.
+- **HTP159W command routing** — Home Assistant initiated open/close commands now use the DP valve control endpoint for `HTP159W`. The legacy `controlWorkMode` endpoint rejects this model with `code=1`, so it needs the same little-endian runtime payload style used by other DP-backed valve models.
+- **MQTT subscription home selection** — `subscribeStatus` now prefers the selected home that actually contains a discovered hub, while still sending the full selected home list. This avoids subscribing with an empty first home when the device lives under a later selected home.
+
+### 🧪 Tests
+- **HTP159W payload fixture** — added the issue #55 `HTP159W` payload to the fixture corpus, covering battery, RSSI, valve state, session duration, event time, and alarm decoding.
+- **State-payload MQTT regressions** — added parser and routing coverage for `state`-carried device payloads, including a guard that RSSI-only `state` messages remain ignored.
+- **DP command regression** — added `HTP159W` command-routing coverage so a 60-second open command builds the expected DP payload (`3c000000`) for `addr=0`, `port=1`.
+
+### ⚠️ Notes
+- **Home Assistant device layout** — `HTP159W` may appear as a parent hub/diagnostic device plus a controllable valve child device. This matches the existing hub-as-device layout used by WiFi controllers and preserves stable entity/device identities.
+- **Live validation scope** — realtime open/close state updates and Home Assistant initiated DP open/close commands have both been validated with a live `HTP159W`.
+
+---
+
 ## [3.0.33] - 2026-05-13
 
 ### 🔧 Diagnostics

--- a/README.md
+++ b/README.md
@@ -232,6 +232,8 @@ BZ501FRF, BZ601FRF, HCS003ARF, HCS003ARF-V1, HCS003FRF, HCS005FRF, HCS008FRF, HC
 
 Valve devices additionally get a **valve open/close** entity and a **duration (minutes)** number entity per zone.
 
+Some WiFi valve controllers and tap timers are also their own controllable device. In Home Assistant these may appear as a parent hub/diagnostic device plus a child valve device, even when the hardware is a single physical unit. This preserves stable diagnostics, valve entities, and device identifiers across hub-as-device models such as `HIC801W` and `HTP159W`.
+
 ### Optional multi-zone device grouping
 
 For multi-zone controllers, you can enable **Settings → Devices & Services → HomGar/RainPoint Cloud → Configure → Options** and turn on:
@@ -259,7 +261,7 @@ The MQTT session is renewed automatically before it expires (based on the `expir
 
 | Device type | MQTT updates | Pattern |
 |---|---|---|
-| Valves (HTV\*, HIC\*) | ✅ Yes | Event-driven on open/close |
+| Valves (HTV\*, HIC\*, HTP159W) | ✅ Yes | Event-driven on open/close |
 | CO₂ sensors (HCS0530THO) | ✅ Yes | ~45 s periodic |
 | Soil moisture (HCS021FRF, HCS026FRF) | ✅ Yes | ~45 s periodic |
 | Flow meters (HCS008FRF) | ✅ Yes | Event-driven when water flows |
@@ -268,6 +270,8 @@ The MQTT session is renewed automatically before it expires (based on the `expir
 | Weather stations (HWS\*) | ✅ Yes | Periodic |
 
 All other models fall back to 2-minute REST polling.
+
+Some main WiFi devices publish their own valve payload under `state` rather than a `D00`/`D01` child status. The integration treats `state` values that look like raw device payloads as realtime device updates, while ignoring normal hub RSSI state strings.
 
 Short `Cycle&Soak` and mist schedules can transition faster than RainPoint’s cloud updates are delivered. In those cases `Current Step End Time` may briefly appear stale until the next MQTT or REST update arrives. `Irrigation End Time` is usually the more stable indicator of the overall run.
 

--- a/custom_components/homgar/__init__.py
+++ b/custom_components/homgar/__init__.py
@@ -35,6 +35,11 @@ PLATFORMS: list[str] = ["sensor", "binary_sensor", "valve", "switch", "number"]
 _MQTT_RENEWAL_BACKOFF_SECONDS = (30, 60, 300, 900)
 
 
+def _select_mqtt_subscription_hid(hubs: list[dict], hids: list) -> int | str | None:
+    """Prefer a selected home that actually has a hub for MQTT subscription."""
+    return next((hub.get("hid") for hub in hubs if hub.get("hid")), hids[0] if hids else None)
+
+
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Legacy YAML setup - not used."""
     return True
@@ -103,9 +108,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 hubs = coordinator.data.get("hubs", []) if coordinator.data else []
                 hids = entry.data.get(CONF_HIDS, [])
                 sub_creds = {}
-                if hubs and hids:
+                subscription_hid = _select_mqtt_subscription_hid(hubs, hids)
+                if hubs and subscription_hid:
                     try:
-                        sub_creds = await client.subscribe_status(hids[0], hubs)
+                        sub_creds = await client.subscribe_status(subscription_hid, hubs, hids)
                         _LOGGER.info(
                             "HomGar [%s]: subscribeStatus returned device=%s productKey=%s host=%s",
                             entry.title,
@@ -403,11 +409,12 @@ async def _async_renew_mqtt_subscription(hass: HomeAssistant, entry: ConfigEntry
         # Get fresh credentials via subscribeStatus
         hubs = coordinator.data.get("hubs", []) if coordinator.data else []
         hids = entry.data.get(CONF_HIDS, [])
-        if not hubs or not hids:
+        subscription_hid = _select_mqtt_subscription_hid(hubs, hids)
+        if not hubs or not subscription_hid:
             _LOGGER.warning("HomGar [%s]: Cannot renew MQTT - no hubs or hids", entry.title)
             return False
             
-        sub_creds = await client.subscribe_status(hids[0], hubs)
+        sub_creds = await client.subscribe_status(subscription_hid, hubs, hids)
         _LOGGER.info(
             "HomGar [%s]: MQTT renewal - subscribeStatus returned device=%s productKey=%s host=%s",
             entry.title,

--- a/custom_components/homgar/api/client.py
+++ b/custom_components/homgar/api/client.py
@@ -331,7 +331,12 @@ class HomGarClient:
             raise HomGarApiError(f"getDeviceStatus failed: {data}")
         return data.get("data", {})
 
-    async def subscribe_status(self, hid: int, hubs: list[dict]) -> dict:
+    async def subscribe_status(
+        self,
+        hid: int,
+        hubs: list[dict],
+        hid_list: list[int] | None = None,
+    ) -> dict:
         """Call /app/device/subscribeStatus to get fresh per-session MQTT credentials.
 
         Returns the full response data dict including:
@@ -345,9 +350,24 @@ class HomGarClient:
             {"deviceName": h.get("deviceName", ""), "mid": h["mid"], "productKey": h.get("productKey", "")}
             for h in hubs
         ]
+        selected_hids: list[str] = []
+
+        def add_hid(value) -> None:
+            if value is None or str(value) == "":
+                return
+            value = str(value)
+            if value not in selected_hids:
+                selected_hids.append(value)
+
+        for candidate in hid_list or []:
+            add_hid(candidate)
+        for hub in hubs:
+            add_hid(hub.get("hid"))
+        add_hid(hid)
+
         payload = {
             "hid": str(hid),
-            "hidList": [str(hid)],
+            "hidList": selected_hids,
             "subscribe": subscribe_list,
             "unsubscribe": [],
             "userInfo": {

--- a/custom_components/homgar/coordinator.py
+++ b/custom_components/homgar/coordinator.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime, timedelta, timezone
+from typing import Any
 
 from homeassistant.core import HomeAssistant
 from homeassistant.components.persistent_notification import async_create
@@ -37,6 +38,25 @@ def _extract_state_rssi(raw_state: str | None) -> int | None:
         return int(parts[1])
     except (TypeError, ValueError):
         return None
+
+
+def _looks_like_device_payload(value: Any) -> bool:
+    """Return True for raw device payload frames such as ``10#...``."""
+    return isinstance(value, str) and "#" in value
+
+
+def _select_hub_as_device_status(sub_status: dict[str, dict]) -> dict | None:
+    """Find the status entry for a WiFi hub that also acts as a device."""
+    for status_id in ("D00", "D0"):
+        entry = sub_status.get(status_id)
+        if entry and entry.get("value"):
+            return entry
+
+    state = sub_status.get("state")
+    if state and _looks_like_device_payload(state.get("value")):
+        return state
+
+    return None
 
 
 def _is_empty_hub_placeholder(hub: dict) -> bool:
@@ -323,15 +343,16 @@ class HomGarCoordinator(DataUpdateCoordinator):
 
                     _LOGGER.debug("Sensor entity key=%s info=%s", sensor_key, decoded_sensors[sensor_key])
 
-                # Handle WiFi hub-as-device (e.g. HIC801W): the hub itself is a
-                # controllable device whose status arrives as D00 in subDeviceStatus.
-                # It never appears in subDevices[], so the loop above skips it.
+                # Handle WiFi hub-as-device (e.g. HIC801W/HTP159W): the hub
+                # itself is a controllable device that never appears in
+                # subDevices[]. Status may arrive as D00/D0 or as a raw
+                # device payload in state.
                 hub_model = hub.get("model") or hub.get("displayModel")
                 if hub_model:
                     if get_valve_ports(hub_model) or get_switch_ports(hub_model):
-                        d00 = sub_status.get("D00") or sub_status.get("D0")
-                        if d00:
-                            raw_value = d00.get("value")
+                        hub_device_status = _select_hub_as_device_status(sub_status)
+                        if hub_device_status:
+                            raw_value = hub_device_status.get("value")
                             decoded = decode_payload(hub_model, raw_value) if raw_value else None
                             sensor_key = f"{mid}_0"
                             if sensor_key not in decoded_sensors:
@@ -344,7 +365,7 @@ class HomGarCoordinator(DataUpdateCoordinator):
                                     "sub_name": hub.get("name") or hub_model,
                                     "model": hub_model,
                                     "firmware_version": hub.get("softVer"),
-                                    "raw_status": d00,
+                                    "raw_status": hub_device_status,
                                     "data": decoded,
                                     "type_flag": 0,
                                 }

--- a/custom_components/homgar/coordinator_mqtt.py
+++ b/custom_components/homgar/coordinator_mqtt.py
@@ -68,12 +68,16 @@ async def handle_mqtt_update(coordinator: "HomGarCoordinator", data: dict) -> No
         len(target_hub.get("subDevices", []))
     )
     
-    # Extract address from device_key (D01 -> addr 1, D02 -> addr 2, etc.)
-    try:
-        addr = int(device_key[1:])
-    except (ValueError, IndexError):
-        _LOGGER.warning("HomGar MQTT: Invalid device_key format: %s", device_key)
-        return
+    # Extract address from device_key (D01 -> addr 1, D02 -> addr 2, etc.).
+    # Some WiFi hub-as-device models publish their own payload under state.
+    if device_key == "state":
+        addr = 0
+    else:
+        try:
+            addr = int(device_key[1:])
+        except (ValueError, IndexError, TypeError):
+            _LOGGER.warning("HomGar MQTT: Invalid device_key format: %s", device_key)
+            return
 
     hub_diag_key = f"rainpoint_hub_{matched_mid}"
     hub_diag = dict(coordinator._mqtt_diagnostics.get(hub_diag_key) or {})

--- a/custom_components/homgar/decoder.py
+++ b/custom_components/homgar/decoder.py
@@ -98,9 +98,10 @@ def get_valve_ports(model: str) -> list[int]:
 
 
 DP_VALVE_CONTROL_MODELS: frozenset[str] = frozenset({
-    # HTV157B exposes CTL_WATER rather than CTL_BT_WATER in product metadata,
-    # but the legacy controlWorkMode endpoint returns code=3 for this model.
+    # These models expose CTL_WATER rather than CTL_BT_WATER in product
+    # metadata, but the legacy controlWorkMode endpoint rejects them.
     "HTV157B",
+    "HTP159W",
 })
 
 

--- a/custom_components/homgar/hub_entities.py
+++ b/custom_components/homgar/hub_entities.py
@@ -40,6 +40,11 @@ def _hub_status_entries(coordinator: HomGarCoordinator, mid: int | str) -> list[
     return entries if isinstance(entries, list) else []
 
 
+def _looks_like_device_payload(value: Any) -> bool:
+    """Return True for raw device payload frames such as ``10#...``."""
+    return isinstance(value, str) and "#" in value
+
+
 class HomGarHubDevice(Entity):
     """Mixin providing device_info for HomGar hub entities."""
 
@@ -177,6 +182,17 @@ class HomGarHubRawStatusSensor(HomGarHubSensorBase):
             )
             if value is not None:
                 return str(value)
+        state_value = next(
+            (
+                entry.get("value")
+                for entry in entries
+                if entry.get("id") == "state"
+                and _looks_like_device_payload(entry.get("value"))
+            ),
+            None,
+        )
+        if state_value is not None:
+            return str(state_value)
         for entry in entries:
             status_id = str(entry.get("id", ""))
             value = entry.get("value")

--- a/custom_components/homgar/manifest.json
+++ b/custom_components/homgar/manifest.json
@@ -13,5 +13,5 @@
         "custom_components.homgar"
     ],
     "requirements": ["paho-mqtt>=1.6.0"],
-    "version": "3.0.33"
+    "version": "3.0.34"
 }

--- a/custom_components/homgar/mqtt_client.py
+++ b/custom_components/homgar/mqtt_client.py
@@ -373,16 +373,30 @@ class HomGarMQTTClient:
                     _LOGGER.warning("HomGar MQTT failed to parse device updates: %s", rest[:100])
                 return
             
-            device_count = sum(1 for key in d_updates if isinstance(key, str) and key.startswith("D"))
+            device_count = sum(
+                1
+                for key, val in d_updates.items()
+                if isinstance(key, str)
+                and (
+                    key.startswith("D")
+                    or (
+                        key == "state"
+                        and _looks_like_device_payload(
+                            val.get("value", "") if isinstance(val, dict) else val
+                        )
+                    )
+                )
+            )
             _LOGGER.debug(
                 "HomGar MQTT update for hub_mid=%s: %d device(s)",
                 hub_mid,
                 device_count,
             )
             
-            # Process each device update (D01, D02, D03, D04, etc.)
+            # Process each device update (D01, D02, D03, D04, etc.) and WiFi
+            # hub-as-device payloads carried in state.
             for key, val in d_updates.items():
-                if not key.startswith("D"):
+                if not key.startswith("D") and key != "state":
                     continue
                 
                 raw_val = val.get("value", "") if isinstance(val, dict) else val

--- a/scripts/pre-commit-docker-test.sh
+++ b/scripts/pre-commit-docker-test.sh
@@ -220,6 +220,16 @@ else
     exit 1
 fi
 
+# ── Test: BLE/DP valve control regressions ─────────────────────────────────
+echo "🧪 Running BLE/DP valve control regression tests..."
+docker cp tests/run_ble_valve_model_tests.py ha-test:/tmp/tests/run_ble_valve_model_tests.py > /dev/null
+if docker exec ha-test python3 /tmp/tests/run_ble_valve_model_tests.py; then
+    echo "✅ BLE/DP valve control regression tests passed"
+else
+    echo "❌ ERROR: BLE/DP valve control regression tests failed"
+    exit 1
+fi
+
 # ── Test: decoder regression suite (scripts/test_decoders.py) ─────────────
 echo "🧪 Running decoder regression suite..."
 docker cp scripts/test_decoders.py ha-test:/tmp/test_decoders.py > /dev/null

--- a/tests/fixtures/payload_index.json
+++ b/tests/fixtures/payload_index.json
@@ -15,6 +15,7 @@
     {"model": "HTV0537FRF", "file": "payloads/HTV0537FRF.json", "sample_count": 2},
     {"model": "HTV0542FRF", "file": "payloads/HTV0542FRF.json", "sample_count": 2},
     {"model": "HIC801W", "file": "payloads/HIC801W.json", "sample_count": 1},
+    {"model": "HTP159W", "file": "payloads/HTP159W.json", "sample_count": 1},
     {"model": "HTP115FRF", "file": "payloads/HTP115FRF.json", "sample_count": 1},
     {"model": "HCS012ARF", "file": "payloads/HCS012ARF.json", "sample_count": 2},
     {"model": "HWS019WRF-V2", "file": "payloads/HWS019WRF-V2.json", "sample_count": 2}

--- a/tests/fixtures/payloads/HTP159W.json
+++ b/tests/fixtures/payloads/HTP159W.json
@@ -1,0 +1,22 @@
+{
+  "model": "HTP159W",
+  "samples": [
+    {
+      "id": "issue-55-state-payload",
+      "source_issue": 55,
+      "source_type": "github_issue",
+      "format": "tlv",
+      "payload": "10#DC0103E1C900D82020B778445B19AF00000000",
+      "expected": {
+        "port_number": 1,
+        "dp_flag": 1,
+        "battery_level": 100,
+        "signal_strength": -55,
+        "valve_state": "idle",
+        "is_watering": false,
+        "current_session_duration": 0,
+        "alarm": 0
+      }
+    }
+  ]
+}

--- a/tests/run_ble_valve_model_tests.py
+++ b/tests/run_ble_valve_model_tests.py
@@ -95,6 +95,10 @@ def main() -> int:
         decoder.uses_ble_valve_control("HTV157B") is True,
     )
     check(
+        "HTP159W uses DP valve control override",
+        decoder.uses_ble_valve_control("HTP159W") is True,
+    )
+    check(
         "HTV203FRF is not detected as BLE-backed",
         decoder.uses_ble_valve_control("HTV203FRF") is False,
     )
@@ -150,6 +154,27 @@ def main() -> int:
             "addr": 1,
             "port": 1,
             "param": "00000000",
+            "dpCode": 1,
+        },
+    )
+    check(
+        "HTP159W open payload uses addr 0 and 60s runtime",
+        client._build_control_work_mode_dp_payload(
+            mid=267334,
+            addr=0,
+            device_name="MAC-9451DCF58178",
+            product_key="k0k0dAkMR17",
+            port=1,
+            mode=1,
+            duration=60,
+        ) == {
+            "mid": "267334",
+            "productKey": "k0k0dAkMR17",
+            "deviceName": "MAC-9451DCF58178",
+            "mode": 1,
+            "addr": 0,
+            "port": 1,
+            "param": "3c000000",
             "dpCode": 1,
         },
     )

--- a/tests/run_mqtt_parser_tests.py
+++ b/tests/run_mqtt_parser_tests.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
+from types import SimpleNamespace
 
 
 def _find_repo_root() -> Path:
@@ -54,6 +56,19 @@ def check(name: str, condition: bool, detail: str = "") -> None:
         FAIL += 1
 
 
+def collect_mqtt_callbacks(param: str) -> list[dict]:
+    """Run _on_message without opening a real MQTT connection."""
+    callbacks: list[dict] = []
+    client = mqtt_client.HomGarMQTTClient.__new__(mqtt_client.HomGarMQTTClient)
+    client._messages_received = 0
+    client._last_message_time = None
+    client._on_message_callback = callbacks.append
+    payload = json.dumps({"params": {"param": param}}).encode()
+    msg = SimpleNamespace(topic="test/topic", payload=payload)
+    client._on_message(None, None, msg)
+    return callbacks
+
+
 def main() -> int:
     print("\n🧪 MQTT parser regression tests")
 
@@ -86,11 +101,25 @@ def main() -> int:
         not looks_like_device_payload("1|1776014190215|103441486619"),
         "expected False",
     )
+    check("rejects hub RSSI state", not looks_like_device_payload("0,-68"), "expected False")
 
     last6, candidates = extract_hub_mid_candidates("P260412163703000017280081139929")
     check("mid extraction keeps raw candidate", last6 == "139929", repr((last6, candidates)))
     check("mid extraction includes raw mid", candidates and candidates[0] == "139929", repr(candidates))
     check("mid extraction includes stripped-leading-1 alias", "39929" in candidates, repr(candidates))
+
+    callbacks = collect_mqtt_callbacks(
+        '#P260513201756000017870151267334|{"state":{"time":1778701510269,'
+        '"value":"10#DC0103E1C900D82020B778445B19AF00000000"}}|0|0#'
+    )
+    check("emits MQTT callback for state device payload", len(callbacks) == 1, repr(callbacks))
+    check("preserves state device key", callbacks and callbacks[0]["device_key"] == "state", repr(callbacks))
+    check("preserves state raw payload", callbacks and callbacks[0]["payload"].startswith("10#DC01"), repr(callbacks))
+
+    callbacks = collect_mqtt_callbacks(
+        '#P260513201756000017870151267334|{"state":{"time":1778701510269,"value":"0,-68"}}|0|0#'
+    )
+    check("ignores MQTT RSSI-only state", callbacks == [], repr(callbacks))
 
     total = PASS + FAIL
     print(f"\n{'=' * 50}")

--- a/tests/run_mqtt_routing_tests.py
+++ b/tests/run_mqtt_routing_tests.py
@@ -162,6 +162,50 @@ async def _run_missing_sensor_case() -> tuple[bool, dict]:
     return coordinator.updated, hub_diag
 
 
+async def _run_state_payload_case() -> tuple[bool, dict, dict, dict]:
+    coordinator = FakeCoordinator()
+    coordinator.data = {
+        "hubs": [
+            {
+                "mid": 267334,
+                "hid": 207006,
+                "name": "Kitchen Plants",
+                "model": "HTP159W",
+                "softVer": "1.1.1020",
+                "subDevices": [],
+            }
+        ],
+        "sensors": {
+            "267334_0": {
+                "hid": 207006,
+                "mid": 267334,
+                "addr": 0,
+                "home_name": "My Home",
+                "hub_name": "Kitchen Plants",
+                "sub_name": "Kitchen Plants",
+                "model": "HTP159W",
+                "firmware_version": "1.1.1020",
+                "raw_status": {"id": "state", "value": "10#DC0103E1C900D82020B778445B19AF00000000"},
+                "data": {},
+                "type_flag": 0,
+            }
+        },
+    }
+    await coordinator_mqtt.handle_mqtt_update(
+        coordinator,
+        {
+            "hub_mid": "267334",
+            "hub_mid_candidates": ["267334"],
+            "device_key": "state",
+            "payload": "10#DC0103E1C900D82020B778445B19AF00000000",
+        },
+    )
+    sensor = coordinator.data["sensors"]["267334_0"]
+    diag = coordinator._mqtt_diagnostics.get("267334_0", {})
+    hub_diag = coordinator._mqtt_diagnostics.get("rainpoint_hub_267334", {})
+    return coordinator.updated, sensor, diag, hub_diag
+
+
 def main() -> int:
     print("\n🧪 MQTT routing regression tests")
     updated, sensor, diag, hub_diag = asyncio.run(_run_case())
@@ -181,6 +225,21 @@ def main() -> int:
         "records hub-level mqtt diagnostics without sensor key",
         missing_sensor_hub_diag.get("raw_payload", "").startswith("10#1088"),
         repr(missing_sensor_hub_diag),
+    )
+
+    state_updated, state_sensor, state_diag, state_hub_diag = asyncio.run(_run_state_payload_case())
+    check("routes state payload update to hub-as-device addr 0", state_updated)
+    check(
+        "updates HTP159W state raw_status",
+        state_sensor["raw_status"]["value"].startswith("10#DC01"),
+        repr(state_sensor),
+    )
+    check("decodes HTP159W state valve idle", state_sensor["data"].get("is_watering") is False, repr(state_sensor["data"]))
+    check("records HTP159W state mqtt diagnostics", bool(state_diag), repr(state_diag))
+    check(
+        "records HTP159W hub-level mqtt diagnostics",
+        state_hub_diag.get("raw_payload", "").startswith("10#DC01"),
+        repr(state_hub_diag),
     )
 
     hic = FakeCoordinator()


### PR DESCRIPTION
## Summary

- Add HTP159W WiFi valve/tap timer support for issue #55.
- Recognize raw device payloads published in the cloud `state` field for REST and MQTT hub-as-device paths.
- Route HTP159W Home Assistant valve commands through `controlWorkModeDP`, including the 60-second `3c000000` runtime payload.
- Prefer the selected home that actually contains a discovered hub when requesting MQTT credentials.

## Validation

- Live HTP159W MQTT open/close state confirmed.
- Live Home Assistant initiated open/close confirmed by the device owner.
- `bash scripts/pre-commit-docker-test.sh`

## Device Audit

- The broader `state` payload handling may help similar standalone WiFi devices.
- HTP149W is the closest unconfirmed watchlist model; HTV143WRFE, HTV124B, and HIC406B are also worth watching if they show `controlWorkMode failed: code=1`.
- The DP command override remains intentionally model-scoped to avoid changing known working `CTL_WATER` devices.
