### PR TITLE
Add valve duration unit option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.0.35] - 2026-05-15
+
+### ✨ Features
+- **Valve duration unit option** — added an integration option to show valve duration number entities in either minutes or seconds. Existing installs continue to default to minutes for backward compatibility, while users who need short watering runs can switch to seconds from the HomGar/RainPoint Options screen.
+
+### 🐛 Bug Fixes
+- **Duration restore safety** — restored duration values preserve their previous unit, so a restored `10 min` duration becomes `600 s` when switching to seconds mode instead of silently becoming `10 s`.
+
+### 🧪 Tests
+- **Duration unit regressions** — added coverage for minute/second conversion, bounds, default behavior, and the one-second minimum in seconds mode.
+- **Docker pre-commit wait** — made the Docker validation gate wait for HomGar setup with a short poll loop instead of a fixed startup sleep.
+
+---
+
 ## [3.0.34] - 2026-05-13
 
 ### 🐛 Bug Fixes

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ BZ501FRF, BZ601FRF, HCS003ARF, HCS003ARF-V1, HCS003FRF, HCS005FRF, HCS008FRF, HC
 | Irrigation End Time | Timestamp | — |
 | precipitation_total / _1h / _24h / _7d | Precipitation | mm |
 
-Valve devices additionally get a **valve open/close** entity and a **duration (minutes)** number entity per zone.
+Valve devices additionally get a **valve open/close** entity and a **duration** number entity per zone. By default the duration is shown in minutes for backward compatibility. You can switch it to seconds in **Settings → Devices & Services → HomGar/RainPoint Cloud → Configure → Options**.
 
 Some WiFi valve controllers and tap timers are also their own controllable device. In Home Assistant these may appear as a parent hub/diagnostic device plus a child valve device, even when the hardware is a single physical unit. This preserves stable diagnostics, valve entities, and device identifiers across hub-as-device models such as `HIC801W` and `HTP159W`.
 

--- a/custom_components/homgar/config_flow.py
+++ b/custom_components/homgar/config_flow.py
@@ -22,8 +22,12 @@ from .const import (
     CONF_HIDS,
     CONF_APP_TYPE,
     CONF_GROUP_MULTI_ZONE_DEVICES,
+    CONF_VALVE_DURATION_UNIT,
     APP_TYPE_HOMGAR,
     APP_TYPE_RAINPOINT,
+    DEFAULT_VALVE_DURATION_UNIT,
+    VALVE_DURATION_UNIT_MINUTES,
+    VALVE_DURATION_UNIT_SECONDS,
 )
 from .country_codes import get_default_country_code
 from .api import HomGarClient, HomGarApiError
@@ -355,6 +359,16 @@ class HomGarOptionsFlow(config_entries.OptionsFlow):
                     CONF_GROUP_MULTI_ZONE_DEVICES,
                     default=self._config_entry.options.get(CONF_GROUP_MULTI_ZONE_DEVICES, False),
                 ): bool,
+                vol.Optional(
+                    CONF_VALVE_DURATION_UNIT,
+                    default=self._config_entry.options.get(
+                        CONF_VALVE_DURATION_UNIT,
+                        DEFAULT_VALVE_DURATION_UNIT,
+                    ),
+                ): vol.In({
+                    VALVE_DURATION_UNIT_MINUTES: "Minutes",
+                    VALVE_DURATION_UNIT_SECONDS: "Seconds",
+                }),
             }
         )
 

--- a/custom_components/homgar/const.py
+++ b/custom_components/homgar/const.py
@@ -7,6 +7,11 @@ CONF_PASSWORD = "password"
 CONF_HIDS = "hids"  # list of selected home IDs
 CONF_APP_TYPE = "app_type"  # "homgar" or "rainpoint"
 CONF_GROUP_MULTI_ZONE_DEVICES = "group_multi_zone_devices"
+CONF_VALVE_DURATION_UNIT = "valve_duration_unit"
+
+VALVE_DURATION_UNIT_MINUTES = "minutes"
+VALVE_DURATION_UNIT_SECONDS = "seconds"
+DEFAULT_VALVE_DURATION_UNIT = VALVE_DURATION_UNIT_MINUTES
 
 DEFAULT_SCAN_INTERVAL = 120  # seconds
 

--- a/custom_components/homgar/manifest.json
+++ b/custom_components/homgar/manifest.json
@@ -13,5 +13,5 @@
         "custom_components.homgar"
     ],
     "requirements": ["paho-mqtt>=1.6.0"],
-    "version": "3.0.34"
+    "version": "3.0.35"
 }

--- a/custom_components/homgar/number.py
+++ b/custom_components/homgar/number.py
@@ -14,6 +14,10 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import (
     DOMAIN,
     CONF_GROUP_MULTI_ZONE_DEVICES,
+    CONF_VALVE_DURATION_UNIT,
+    DEFAULT_VALVE_DURATION_UNIT,
+    VALVE_DURATION_UNIT_MINUTES,
+    VALVE_DURATION_UNIT_SECONDS,
     controller_device_identifier,
     format_port_device_name,
     format_port_entity_name,
@@ -24,10 +28,48 @@ from .decoder import get_valve_ports
 
 _LOGGER = logging.getLogger(__name__)
 
+DURATION_MIN_SECONDS = 1
+DURATION_MAX_SECONDS = 3600
+DURATION_STEP_SECONDS = 1
+DURATION_DEFAULT_SECONDS = 600
 DURATION_MIN_MINUTES = 1
 DURATION_MAX_MINUTES = 60
 DURATION_STEP_MINUTES = 1
-DURATION_DEFAULT_MINUTES = 10
+
+
+def _duration_unit_from_options(coordinator: HomGarCoordinator) -> str:
+    """Return the configured duration number unit."""
+    unit = coordinator._entry.options.get(CONF_VALVE_DURATION_UNIT, DEFAULT_VALVE_DURATION_UNIT)
+    if unit == VALVE_DURATION_UNIT_SECONDS:
+        return VALVE_DURATION_UNIT_SECONDS
+    return VALVE_DURATION_UNIT_MINUTES
+
+
+def _duration_seconds_from_native(value: float, unit: str) -> int:
+    """Convert a duration number's native value to seconds."""
+    if unit == VALVE_DURATION_UNIT_SECONDS:
+        return int(value)
+    return int(value * 60)
+
+
+def _duration_native_from_seconds(seconds: int, unit: str) -> float:
+    """Convert seconds to the duration number's configured native unit."""
+    if unit == VALVE_DURATION_UNIT_SECONDS:
+        return float(seconds)
+    return seconds / 60
+
+
+def _duration_bounds_seconds(unit: str) -> tuple[int, int]:
+    """Return valid duration bounds in seconds for the configured unit."""
+    if unit == VALVE_DURATION_UNIT_SECONDS:
+        return DURATION_MIN_SECONDS, DURATION_MAX_SECONDS
+    return DURATION_MIN_MINUTES * 60, DURATION_MAX_MINUTES * 60
+
+
+def _clamp_duration_seconds(seconds: int, unit: str) -> int:
+    """Clamp a duration to the range representable by the configured unit."""
+    minimum, maximum = _duration_bounds_seconds(unit)
+    return min(max(seconds, minimum), maximum)
 
 
 async def async_setup_entry(
@@ -61,17 +103,13 @@ async def async_setup_entry(
 
 
 class HomGarZoneDurationNumber(CoordinatorEntity, NumberEntity, RestoreEntity):
-    """Configurable run duration (in minutes) for a single irrigation zone.
+    """Configurable run duration for a single irrigation zone.
 
     The value is restored on HA restart via RestoreEntity.  When a valve is
     opened without an explicit duration override in the service call data,
     valve.py reads this entity's current value and converts it to seconds.
     """
 
-    _attr_native_min_value = DURATION_MIN_MINUTES
-    _attr_native_max_value = DURATION_MAX_MINUTES
-    _attr_native_step = DURATION_STEP_MINUTES
-    _attr_native_unit_of_measurement = UnitOfTime.MINUTES
     _attr_mode = NumberMode.BOX
     _attr_icon = "mdi:timer-outline"
 
@@ -86,7 +124,22 @@ class HomGarZoneDurationNumber(CoordinatorEntity, NumberEntity, RestoreEntity):
         self._sensor_key = sensor_key
         self._sensor_info = sensor_info
         self._zone_num = zone_num
-        self._current_value: float = DURATION_DEFAULT_MINUTES
+        self._duration_unit = _duration_unit_from_options(coordinator)
+        self._current_seconds = _clamp_duration_seconds(
+            DURATION_DEFAULT_SECONDS,
+            self._duration_unit,
+        )
+
+        if self._duration_unit == VALVE_DURATION_UNIT_SECONDS:
+            self._attr_native_min_value = DURATION_MIN_SECONDS
+            self._attr_native_max_value = DURATION_MAX_SECONDS
+            self._attr_native_step = DURATION_STEP_SECONDS
+            self._attr_native_unit_of_measurement = UnitOfTime.SECONDS
+        else:
+            self._attr_native_min_value = DURATION_MIN_MINUTES
+            self._attr_native_max_value = DURATION_MAX_MINUTES
+            self._attr_native_step = DURATION_STEP_MINUTES
+            self._attr_native_unit_of_measurement = UnitOfTime.MINUTES
 
         hid = sensor_info["hid"]
         mid = sensor_info["mid"]
@@ -111,26 +164,39 @@ class HomGarZoneDurationNumber(CoordinatorEntity, NumberEntity, RestoreEntity):
         if last_state is not None:
             try:
                 restored = float(last_state.state)
-                if DURATION_MIN_MINUTES <= restored <= DURATION_MAX_MINUTES:
-                    self._current_value = restored
+                restored_unit = last_state.attributes.get("unit_of_measurement")
+                if restored_unit == UnitOfTime.SECONDS:
+                    restored_seconds = int(restored)
+                else:
+                    # Legacy duration entities were always stored as minutes.
+                    restored_seconds = int(restored * 60)
+                self._current_seconds = _clamp_duration_seconds(
+                    restored_seconds,
+                    self._duration_unit,
+                )
+                if DURATION_MIN_SECONDS <= restored_seconds <= DURATION_MAX_SECONDS:
                     _LOGGER.debug(
-                        "Restored duration for %s: %s min",
-                        self._attr_unique_id, restored,
+                        "Restored duration for %s: %ss",
+                        self._attr_unique_id, self._current_seconds,
                     )
             except (ValueError, TypeError):
                 pass
 
     @property
     def native_value(self) -> float:
-        return self._current_value
+        return _duration_native_from_seconds(self._current_seconds, self._duration_unit)
 
     async def async_set_native_value(self, value: float) -> None:
-        self._current_value = value
+        seconds = _duration_seconds_from_native(float(value), self._duration_unit)
+        self._current_seconds = _clamp_duration_seconds(seconds, self._duration_unit)
         self.async_write_ha_state()
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        attrs: dict[str, Any] = {}
+        attrs: dict[str, Any] = {
+            "duration_unit": self._duration_unit,
+            "duration_seconds": self._current_seconds,
+        }
         
         # Add firmware version from sensor info
         sensors = self.coordinator.data.get("sensors", {})

--- a/custom_components/homgar/translations/en.json
+++ b/custom_components/homgar/translations/en.json
@@ -62,12 +62,14 @@
         "step": {
             "init": {
                 "title": "HomGar/RainPoint Options",
-                "description": "Adjust how multi-zone controllers are presented in Home Assistant.",
+                "description": "Adjust how HomGar/RainPoint devices are presented in Home Assistant.",
                 "data": {
-                    "group_multi_zone_devices": "Create a separate Home Assistant device for each controller zone"
+                    "group_multi_zone_devices": "Create a separate Home Assistant device for each controller zone",
+                    "valve_duration_unit": "Valve duration control unit"
                 },
                 "data_description": {
-                    "group_multi_zone_devices": "When enabled, per-zone valves, durations, and per-port sensors are grouped under child devices. Shared diagnostics stay on the parent controller device."
+                    "group_multi_zone_devices": "When enabled, per-zone valves, durations, and per-port sensors are grouped under child devices. Shared diagnostics stay on the parent controller device.",
+                    "valve_duration_unit": "Choose whether valve duration number entities are shown in minutes or seconds. Existing installs default to minutes."
                 }
             }
         }

--- a/custom_components/homgar/valve.py
+++ b/custom_components/homgar/valve.py
@@ -15,6 +15,9 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import (
     DOMAIN,
     CONF_GROUP_MULTI_ZONE_DEVICES,
+    CONF_VALVE_DURATION_UNIT,
+    DEFAULT_VALVE_DURATION_UNIT,
+    VALVE_DURATION_UNIT_SECONDS,
     controller_device_identifier,
     format_port_device_name,
     format_port_entity_name,
@@ -25,8 +28,7 @@ from .decoder import get_valve_ports, uses_ble_valve_control
 
 _LOGGER = logging.getLogger(__name__)
 
-# Default run duration used when HA opens a valve without an explicit duration.
-# Users can override by calling the valve.open_valve service with a duration attr.
+# Default run duration used when HA opens a valve without a duration entity.
 DEFAULT_DURATION_SECONDS = 600  # 10 minutes
 
 
@@ -210,8 +212,9 @@ class HomGarValveEntity(CoordinatorEntity, ValveEntity):
     # ------------------------------------------------------------------
 
     def _get_configured_duration_seconds(self) -> int:
-        """Look up the companion duration number entity for this zone and convert
-        its value (minutes) to seconds.  Falls back to DEFAULT_DURATION_SECONDS
+        """Look up the companion duration number entity and convert its value to seconds.
+
+        Falls back to DEFAULT_DURATION_SECONDS
         if the entity is not yet available.
 
         Uses the entity registry to resolve unique_id -> entity_id so the lookup
@@ -226,8 +229,14 @@ class HomGarValveEntity(CoordinatorEntity, ValveEntity):
             state = self.hass.states.get(entity_id)
             if state is not None:
                 try:
-                    minutes = float(state.state)
-                    return max(1, int(minutes * 60))
+                    value = float(state.state)
+                    duration_unit = self.coordinator._entry.options.get(
+                        CONF_VALVE_DURATION_UNIT,
+                        DEFAULT_VALVE_DURATION_UNIT,
+                    )
+                    if duration_unit == VALVE_DURATION_UNIT_SECONDS:
+                        return max(1, int(value))
+                    return max(1, int(value * 60))
                 except (ValueError, TypeError):
                     pass
         _LOGGER.debug(

--- a/scripts/pre-commit-docker-test.sh
+++ b/scripts/pre-commit-docker-test.sh
@@ -37,7 +37,14 @@ docker cp custom_components/homgar ha-test:/config/custom_components/ > /dev/nul
 echo "🔄 Restarting Docker container..."
 docker restart ha-test > /dev/null 2>&1
 echo "⏳ Waiting for HA to start..."
-sleep 25
+SETUP_FOUND=0
+for i in {1..12}; do
+    sleep 5
+    if docker exec ha-test tail -1000 /config/home-assistant.log 2>&1 | grep -q "Setup of domain homgar took"; then
+        SETUP_FOUND=1
+        break
+    fi
+done
 
 # Check HA log file (HA logs to file, not stdout)
 # Use more lines since log accumulates across restarts
@@ -59,10 +66,10 @@ if echo "$RECENT_LOGS" | grep -q "No module named"; then
     echo "$RECENT_LOGS" | grep "No module named" -A 2 | tail -10
     exit 1
 fi
-if echo "$RECENT_LOGS" | grep -q "Setup of domain homgar took"; then
+if [ "$SETUP_FOUND" -eq 1 ] || echo "$RECENT_LOGS" | grep -q "Setup of domain homgar took"; then
     echo "✅ HomGar integration setup successfully"
 else
-    echo "❌ ERROR: Integration did not set up within 30s"
+    echo "❌ ERROR: Integration did not set up within 60s"
     echo "$RECENT_LOGS" | grep -i "homgar" | tail -5
     exit 1
 fi
@@ -217,6 +224,16 @@ if docker exec ha-test python3 /tmp/tests/run_zone_device_tests.py; then
     echo "✅ Zone device regression tests passed"
 else
     echo "❌ ERROR: Zone device regression tests failed"
+    exit 1
+fi
+
+# ── Test: duration unit option regressions ─────────────────────────────────
+echo "🧪 Running duration unit regression tests..."
+docker cp tests/run_duration_unit_tests.py ha-test:/tmp/tests/run_duration_unit_tests.py > /dev/null
+if docker exec ha-test python3 /tmp/tests/run_duration_unit_tests.py; then
+    echo "✅ Duration unit regression tests passed"
+else
+    echo "❌ ERROR: Duration unit regression tests failed"
     exit 1
 fi
 

--- a/tests/run_duration_unit_tests.py
+++ b/tests/run_duration_unit_tests.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Regression tests for valve duration unit options."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+
+ROOT = Path(__file__).resolve().parents[1]
+for candidate in (Path(__file__).resolve().parent, Path.cwd(), Path("/config")):
+    current = candidate
+    while True:
+        if (current / "custom_components" / "homgar" / "number.py").exists():
+            ROOT = current
+            break
+        if current.parent == current:
+            break
+        current = current.parent
+    if (ROOT / "custom_components" / "homgar" / "number.py").exists():
+        break
+sys.path.insert(0, str(ROOT))
+
+from custom_components.homgar import number  # noqa: E402
+from custom_components.homgar.const import (  # noqa: E402
+    CONF_VALVE_DURATION_UNIT,
+    DEFAULT_VALVE_DURATION_UNIT,
+    VALVE_DURATION_UNIT_MINUTES,
+    VALVE_DURATION_UNIT_SECONDS,
+)
+
+PASS = 0
+FAIL = 0
+
+
+def check(name: str, condition: bool, detail: str = "") -> None:
+    global PASS, FAIL
+    if condition:
+        print(f"  ✅ {name}")
+        PASS += 1
+    else:
+        print(f"  ❌ {name}: {detail}")
+        FAIL += 1
+
+
+def fake_coordinator(options: dict | None = None):
+    return SimpleNamespace(_entry=SimpleNamespace(options=options or {}))
+
+
+def main() -> int:
+    print("\n🧪 Valve duration unit regression tests")
+
+    check(
+        "default duration unit is minutes",
+        number._duration_unit_from_options(fake_coordinator()) == DEFAULT_VALVE_DURATION_UNIT,
+    )
+    check(
+        "seconds option is honored",
+        number._duration_unit_from_options(
+            fake_coordinator({CONF_VALVE_DURATION_UNIT: VALVE_DURATION_UNIT_SECONDS})
+        ) == VALVE_DURATION_UNIT_SECONDS,
+    )
+    check(
+        "invalid option falls back to minutes",
+        number._duration_unit_from_options(
+            fake_coordinator({CONF_VALVE_DURATION_UNIT: "hours"})
+        ) == VALVE_DURATION_UNIT_MINUTES,
+    )
+    check(
+        "10 native minutes converts to 600 seconds",
+        number._duration_seconds_from_native(10, VALVE_DURATION_UNIT_MINUTES) == 600,
+    )
+    check(
+        "30 native seconds stays 30 seconds",
+        number._duration_seconds_from_native(30, VALVE_DURATION_UNIT_SECONDS) == 30,
+    )
+    check(
+        "600 seconds renders as 10 minutes",
+        number._duration_native_from_seconds(600, VALVE_DURATION_UNIT_MINUTES) == 10,
+    )
+    check(
+        "30 seconds renders as 30 seconds",
+        number._duration_native_from_seconds(30, VALVE_DURATION_UNIT_SECONDS) == 30,
+    )
+    check(
+        "minutes mode clamps to one minute minimum",
+        number._clamp_duration_seconds(30, VALVE_DURATION_UNIT_MINUTES) == 60,
+    )
+    check(
+        "seconds mode allows one-second minimum",
+        number._clamp_duration_seconds(0, VALVE_DURATION_UNIT_SECONDS) == 1,
+    )
+    check(
+        "seconds mode clamps to one-hour maximum",
+        number._clamp_duration_seconds(7200, VALVE_DURATION_UNIT_SECONDS) == 3600,
+    )
+
+    total = PASS + FAIL
+    print(f"\n{'=' * 50}")
+    print(f"Valve duration unit results: {PASS}/{total} passed, {FAIL} failed")
+    return 0 if FAIL == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Add an integration option for valve duration number entities to use either minutes or seconds.
- Keep existing installs on minutes by default for backward compatibility.
- Preserve restored duration meaning when switching units, so a restored `10 min` value becomes `600 s` in seconds mode.
- Add duration conversion regression coverage and make the Docker pre-commit HA startup wait less brittle.

## Validation

- `bash scripts/pre-commit-docker-test.sh`
- Commit hook repeated the full Docker pre-commit suite successfully.

## Notes

- Seconds mode is available under **Settings → Devices & Services → HomGar/RainPoint Cloud → Configure → Options → Valve duration control unit**.
- No entity unique IDs are changed.
