### PR TITLE
Release 3.0.37: preserve manual device areas across reloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.0.37] - 2026-07-03
+
+### 🐛 Bug Fixes
+- **Preserve manual device areas** — the integration no longer forces devices back to the home-named area on every startup/reload. Areas are now seeded only on first discovery (when a device has no area yet), so a device you move to a different area keeps that area across restarts and reloads. ([#63](https://github.com/brettmeyerowitz/homeassistant-homgar/issues/63))
+
+---
+
 ## [3.0.36] - 2026-07-02
 
 ### ✨ Features

--- a/custom_components/homgar/__init__.py
+++ b/custom_components/homgar/__init__.py
@@ -348,7 +348,14 @@ def _ensure_device_registry_parents(
 
 
 def _assign_devices_to_areas(hass: HomeAssistant, entry: ConfigEntry, coordinator) -> None:
-    """Create HA Areas for each home and assign all homgar devices to them."""
+    """Create an HA Area per home and seed devices into it on first discovery.
+
+    Area assignment only happens for devices that do not already have an area
+    (``area_id is None``). A device the user has manually moved to another area
+    keeps that area across restarts and reloads; we never overwrite a user's
+    choice here. Device name/model backfill still runs unconditionally (see
+    issue #63).
+    """
     from homeassistant.helpers import area_registry as ar, device_registry as dr
 
     data = coordinator.data
@@ -377,7 +384,7 @@ def _assign_devices_to_areas(hass: HomeAssistant, entry: ConfigEntry, coordinato
         hub_device = device_reg.async_get_device(identifiers={(DOMAIN, f"rainpoint_hub_{mid}")})
         if hub_device:
             update: dict = {}
-            if hub_device.area_id != area.id:
+            if hub_device.area_id is None:
                 update["area_id"] = area.id
             if not hub_device.name:
                 update["name"] = _fallback_hub_name(hub_info)
@@ -402,7 +409,7 @@ def _assign_devices_to_areas(hass: HomeAssistant, entry: ConfigEntry, coordinato
             area = area_reg.async_create(home_name)
 
         device = device_reg.async_get_device(identifiers={(DOMAIN, f"{mid}_{addr}")})
-        if device and device.area_id != area.id:
+        if device and device.area_id is None:
             device_reg.async_update_device(device.id, area_id=area.id)
 
         model = sensor_info.get("model")
@@ -411,7 +418,7 @@ def _assign_devices_to_areas(hass: HomeAssistant, entry: ConfigEntry, coordinato
                 zone_device = device_reg.async_get_device(
                     identifiers={(DOMAIN, zone_device_identifier(mid, addr, port))}
                 )
-                if zone_device and zone_device.area_id != area.id:
+                if zone_device and zone_device.area_id is None:
                     device_reg.async_update_device(zone_device.id, area_id=area.id)
 
 

--- a/custom_components/homgar/manifest.json
+++ b/custom_components/homgar/manifest.json
@@ -13,5 +13,5 @@
         "custom_components.homgar"
     ],
     "requirements": ["paho-mqtt>=1.6.0"],
-    "version": "3.0.36"
+    "version": "3.0.37"
 }


### PR DESCRIPTION
## Summary

Fixes **#63** — manual device area assignments are no longer reverted on restart/reload.

### 🐛 Bug
`_assign_devices_to_areas` ran on every setup and re-asserted each device's home-named area whenever it differed from the current area — so moving a device (e.g. to "Voortuin" / "Achtertuin") was undone on the next reload.

### ✅ Fix
Area is now seeded **only on first discovery** (`area_id is None`). A device the user has moved keeps its area across restarts and reloads. Hub name/model backfill is unchanged. HA's `suggested_area` still handles initial placement for newly discovered devices.

### Scope
This glue code isn't unit-testable in the repo's decoder-focused harness (it depends on the live HA device/area registries), so it's validated via the full Docker gate: real HA setup completes cleanly with the change, and all regression suites pass (decoder 84/84, fixture corpus 338/338, MQTT/zone/duration/BLE suites green).
