### PR TITLE
Renew MQTT subscription before credential expiry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.0.38] - 2026-07-04
+
+### 🐛 Bug Fixes
+- **Renew MQTT subscription before credentials expire** — `subscribeStatus` credentials expire ~570 seconds after they are issued, but both renewal-scheduling sites forced the renewal up to a fixed 30-minute (1800s) floor. Credentials therefore lapsed ~9.5 minutes after every (re)subscribe and the renewal did not fire for another ~20 minutes, so the real-time MQTT feed silently ran on expired credentials during that window: device state went stale and the 120-second coordinator poll reverted optimistic valve opens ~2 minutes after each command (while the physical valve kept running). Renewal is now scheduled ~60 seconds before the real credential expiry with a 120-second anti-thrash floor. The v3.0.36 retry backoff already guards every failure path, so this only changes the success-path cadence (~7 lightweight renewals/hour). ([#68](https://github.com/brettmeyerowitz/homeassistant-homgar/issues/68), [#69](https://github.com/brettmeyerowitz/homeassistant-homgar/pull/69))
+
+---
+
 ## [3.0.37] - 2026-07-03
 
 ### 🐛 Bug Fixes

--- a/custom_components/homgar/__init__.py
+++ b/custom_components/homgar/__init__.py
@@ -157,15 +157,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     try:
                         expire_ts = int(expire_ms) / 1000.0
                         now = time.time()
-                        renew_in = max(60, expire_ts - now - 60)
-                        # Enforce minimum 30 min renewal interval to prevent excessive reloads
-                        MIN_RENEWAL_INTERVAL = 1800  # 30 minutes
-                        if renew_in < MIN_RENEWAL_INTERVAL:
-                            _LOGGER.info(
-                                "HomGar [%s]: MQTT renewal would be in %.0fs (too frequent), extending to %.0fs",
-                                entry.title, renew_in, MIN_RENEWAL_INTERVAL
-                            )
-                            renew_in = MIN_RENEWAL_INTERVAL
+                        # subscribeStatus credentials expire ~570s after issue;
+                        # schedule the renewal shortly BEFORE expiry (small
+                        # anti-thrash floor) so the MQTT feed never runs on
+                        # lapsed credentials. A fixed 30-minute floor left MQTT
+                        # dead from ~570s to 1800s after every (re)subscribe:
+                        # states went stale and the coordinator poll reverted
+                        # optimistic valve opens ~2 minutes in.
+                        renew_in = max(120, expire_ts - now - 60)
                         actual_expire = datetime.fromtimestamp(expire_ts).isoformat()
                         _LOGGER.info(
                             "HomGar [%s]: MQTT subscription expires at %s (in %.0fs), scheduling renewal in %.0fs",
@@ -517,10 +516,9 @@ async def _async_renew_mqtt_subscription(hass: HomeAssistant, entry: ConfigEntry
             try:
                 expire_ts = int(expire_ms) / 1000.0
                 now = time.time()
-                renew_in = max(60, expire_ts - now - 60)
-                MIN_RENEWAL_INTERVAL = 1800  # 30 minutes
-                if renew_in < MIN_RENEWAL_INTERVAL:
-                    renew_in = MIN_RENEWAL_INTERVAL
+                # Renew shortly before the real credential expiry — see the
+                # matching comment in async_setup_entry.
+                renew_in = max(120, expire_ts - now - 60)
                 _LOGGER.info(
                     "HomGar [%s]: MQTT renewal complete - next renewal scheduled in %.0fs",
                     entry.title, renew_in

--- a/custom_components/homgar/manifest.json
+++ b/custom_components/homgar/manifest.json
@@ -13,5 +13,5 @@
         "custom_components.homgar"
     ],
     "requirements": ["paho-mqtt>=1.6.0"],
-    "version": "3.0.37"
+    "version": "3.0.38"
 }


### PR DESCRIPTION
Fixes #68

`subscribeStatus` credentials expire ~570 s after issue, but both renewal-scheduling sites floor `renew_in` at `MIN_RENEWAL_INTERVAL = 1800`. Credentials lapse ~9.5 minutes in; renewal fires ~20 minutes later; in between, the real-time MQTT feed runs dead on expired credentials, device state goes stale, and the 120 s coordinator poll reverts optimistic valve opens ~2 minutes after each command (the physical valve keeps running). The reconnect thread can't recover — it re-signs the frozen, expired `deviceSecret` and gives up after 5 attempts.

This change schedules the renewal ~60 s before the actual `expire` timestamp with a 120 s anti-thrash floor, at both sites (setup path and recurring-renewal path):

```python
renew_in = max(120, expire_ts - now - 60)
```

The 1800 s floor's "prevent excessive reloads" concern doesn't bite at the credential cadence (~7 lightweight renewals/hour), and the v3.0.36 `_schedule_mqtt_renewal_retry` backoff already guards every failure path against thrash — this PR only touches the success-path scheduling.

**Verified in production** (RainPoint hub, 13 devices, HA 2026.6.4): renewal fires at ~509 s cadence and re-arms indefinitely (`MQTT renewal complete - next renewal scheduled in 509s` across many hours); valve opens hold `valve_state=irrigation` / `src=mqtt` past the coordinator poll with no phantom revert.
