### PR TITLE
Only seed device areas on first setup (fixes #70)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.0.39] - 2026-07-04
+
+### 🐛 Bug Fixes
+- **Deleted "My Home" area no longer comes back after a reload** — the integration created its per-home area and re-assigned devices to it on *every* setup. Deleting an area in Home Assistant nulls the `area_id` of every device that was in it, which the old code read as "unseeded" and used to recreate the area and re-home the devices on the next reload. Area creation and assignment now happen only on the **first setup** of a config entry; reloads leave areas alone, so an area you remove stays removed. Device name/model backfill still runs on every reload. New devices added later are still grouped via `suggested_area` at registration time. ([#70](https://github.com/brettmeyerowitz/homeassistant-homgar/issues/70))
+
 ## [3.0.38] - 2026-07-04
 
 ### 🐛 Bug Fixes

--- a/custom_components/homgar/__init__.py
+++ b/custom_components/homgar/__init__.py
@@ -22,8 +22,8 @@ from .const import (
     CONF_APP_TYPE,
     CONF_HIDS,
     controller_device_identifier,
-    zone_device_identifier,
 )
+from .areas import seed_device_areas, _fallback_hub_name
 from .coordinator import HomGarCoordinator
 from .decoder import _MODELS, get_switch_ports, get_valve_ports  # noqa: F401 — imported here to trigger eager file load in executor
 from .api import HomGarClient
@@ -247,6 +247,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Set up services
     await async_setup_services(hass)
 
+    # Detect a fresh install BEFORE any devices are created this cycle. Areas are
+    # seeded only on first setup; on reloads we leave areas untouched so a
+    # user-deleted area is not recreated (issue #70).
+    is_first_setup = not dr.async_entries_for_config_entry(dr.async_get(hass), entry.entry_id)
+
     _ensure_device_registry_parents(hass, entry, coordinator)
 
     _LOGGER.info("Setting up platforms: %s for entry: %s", PLATFORMS, entry.entry_id)
@@ -266,7 +271,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             _LOGGER.info("HomGar [%s]: Finalizing device layout", entry.title)
             await async_merge_wifi_devices(hass, entry, coordinator)
             await async_rehome_multi_zone_entities(hass, entry, coordinator)
-            _assign_devices_to_areas(hass, entry, coordinator)
+            seed_device_areas(hass, entry, coordinator, is_first_setup)
             _LOGGER.info("HomGar [%s]: Device layout finalized", entry.title)
         except Exception as ex:  # noqa: BLE001
             _LOGGER.warning("HomGar [%s]: Device layout finalization failed: %s", entry.title, ex, exc_info=True)
@@ -280,16 +285,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry.async_on_unload(async_call_later(hass, 2, _async_finalize_device_layout_later))
 
     return True
-
-
-def _fallback_hub_name(hub_info: dict) -> str:
-    model = hub_info.get("model")
-    return (
-        hub_info.get("name")
-        or hub_info.get("displayModel")
-        or (model if model and model != "Unknown" else None)
-        or "RainPoint Hub"
-    )
 
 
 def _ensure_device_registry_parents(
@@ -344,81 +339,6 @@ def _ensure_device_registry_parents(
             suggested_area=sensor_info.get("home_name"),
             via_device=(DOMAIN, f"rainpoint_hub_{mid}"),
         )
-
-
-def _assign_devices_to_areas(hass: HomeAssistant, entry: ConfigEntry, coordinator) -> None:
-    """Create an HA Area per home and seed devices into it on first discovery.
-
-    Area assignment only happens for devices that do not already have an area
-    (``area_id is None``). A device the user has manually moved to another area
-    keeps that area across restarts and reloads; we never overwrite a user's
-    choice here. Device name/model backfill still runs unconditionally (see
-    issue #63).
-    """
-    from homeassistant.helpers import area_registry as ar, device_registry as dr
-
-    data = coordinator.data
-    if not data:
-        return
-
-    area_reg = ar.async_get(hass)
-    device_reg = dr.async_get(hass)
-
-    hubs = data.get("hubs", [])
-    if isinstance(hubs, dict):
-        hubs = list(hubs.values())
-
-    for hub_info in hubs:
-        home_name = hub_info.get("homeName") or ""
-        if not home_name:
-            continue
-        mid = hub_info.get("mid")
-        if not mid:
-            continue
-
-        area = area_reg.async_get_area_by_name(home_name)
-        if not area:
-            area = area_reg.async_create(home_name)
-
-        hub_device = device_reg.async_get_device(identifiers={(DOMAIN, f"rainpoint_hub_{mid}")})
-        if hub_device:
-            update: dict = {}
-            if hub_device.area_id is None:
-                update["area_id"] = area.id
-            if not hub_device.name:
-                update["name"] = _fallback_hub_name(hub_info)
-            if not hub_device.model:
-                update["model"] = hub_info.get("model") or hub_info.get("displayModel") or "Unknown"
-            if update:
-                device_reg.async_update_device(hub_device.id, **update)
-
-    sensors = data.get("sensors", {})
-    group_multi_zone = entry.options.get(CONF_GROUP_MULTI_ZONE_DEVICES, False)
-    for sensor_info in sensors.values():
-        home_name = sensor_info.get("home_name") or ""
-        if not home_name:
-            continue
-        mid = sensor_info.get("mid")
-        addr = sensor_info.get("addr")
-        if mid is None or addr is None:
-            continue
-
-        area = area_reg.async_get_area_by_name(home_name)
-        if not area:
-            area = area_reg.async_create(home_name)
-
-        device = device_reg.async_get_device(identifiers={(DOMAIN, f"{mid}_{addr}")})
-        if device and device.area_id is None:
-            device_reg.async_update_device(device.id, area_id=area.id)
-
-        model = sensor_info.get("model")
-        if group_multi_zone and model and len(get_valve_ports(model)) > 1:
-            for port in get_valve_ports(model):
-                zone_device = device_reg.async_get_device(
-                    identifiers={(DOMAIN, zone_device_identifier(mid, addr, port))}
-                )
-                if zone_device and zone_device.area_id is None:
-                    device_reg.async_update_device(zone_device.id, area_id=area.id)
 
 
 async def _async_renew_mqtt_subscription(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/homgar/areas.py
+++ b/custom_components/homgar/areas.py
@@ -1,0 +1,126 @@
+"""Area seeding for HomGar devices.
+
+Home Assistant areas are seeded from the HomGar "home" name, but only on the
+**first setup** of a config entry. After that the integration never creates or
+(re)assigns areas, so a user who deletes the auto-created area keeps it deleted
+across reloads (issue #70). Device name/model backfill still runs on every
+reload (issue #63).
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .const import CONF_GROUP_MULTI_ZONE_DEVICES, DOMAIN, zone_device_identifier
+from .decoder import get_valve_ports
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+
+
+def _fallback_hub_name(hub_info: dict) -> str:
+    model = hub_info.get("model")
+    return (
+        hub_info.get("name")
+        or hub_info.get("displayModel")
+        or (model if model and model != "Unknown" else None)
+        or "RainPoint Hub"
+    )
+
+
+def seed_device_areas(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    coordinator,
+    is_first_setup: bool,
+) -> None:
+    """Create an HA area per home and seed devices into it on first setup only.
+
+    Area creation and assignment happen only when ``is_first_setup`` is true (a
+    fresh config entry with no devices yet). On every subsequent reload the
+    integration leaves areas alone: deleting an area in HA nulls the devices'
+    ``area_id``, and recreating it on reload is exactly the #70 bug. New devices
+    added to an existing install are still grouped via ``suggested_area`` at the
+    moment they are first registered.
+
+    Device name/model backfill is independent of area seeding and runs on every
+    reload (issue #63).
+    """
+    from homeassistant.helpers import area_registry as ar, device_registry as dr
+
+    data = coordinator.data
+    if not data:
+        return
+
+    area_reg = ar.async_get(hass)
+    device_reg = dr.async_get(hass)
+
+    def _seed_area(home_name: str):
+        """Return the area for ``home_name``, creating it only on first setup."""
+        area = area_reg.async_get_area_by_name(home_name)
+        if not area and is_first_setup:
+            area = area_reg.async_create(home_name)
+        return area
+
+    hubs = data.get("hubs", [])
+    if isinstance(hubs, dict):
+        hubs = list(hubs.values())
+
+    for hub_info in hubs:
+        home_name = hub_info.get("homeName") or ""
+        if not home_name:
+            continue
+        mid = hub_info.get("mid")
+        if not mid:
+            continue
+
+        hub_device = device_reg.async_get_device(identifiers={(DOMAIN, f"rainpoint_hub_{mid}")})
+        if not hub_device:
+            continue
+
+        update: dict = {}
+        # Name/model backfill runs unconditionally (issue #63).
+        if not hub_device.name:
+            update["name"] = _fallback_hub_name(hub_info)
+        if not hub_device.model:
+            update["model"] = hub_info.get("model") or hub_info.get("displayModel") or "Unknown"
+        # Area assignment only on first setup (issue #70).
+        if is_first_setup and hub_device.area_id is None:
+            area = _seed_area(home_name)
+            if area:
+                update["area_id"] = area.id
+        if update:
+            device_reg.async_update_device(hub_device.id, **update)
+
+    # Everything below is pure area seeding — skip entirely after first setup so
+    # deleted areas are not recreated and user-cleared devices are not reassigned.
+    if not is_first_setup:
+        return
+
+    sensors = data.get("sensors", {})
+    group_multi_zone = entry.options.get(CONF_GROUP_MULTI_ZONE_DEVICES, False)
+    for sensor_info in sensors.values():
+        home_name = sensor_info.get("home_name") or ""
+        if not home_name:
+            continue
+        mid = sensor_info.get("mid")
+        addr = sensor_info.get("addr")
+        if mid is None or addr is None:
+            continue
+
+        area = _seed_area(home_name)
+        if not area:
+            continue
+
+        device = device_reg.async_get_device(identifiers={(DOMAIN, f"{mid}_{addr}")})
+        if device and device.area_id is None:
+            device_reg.async_update_device(device.id, area_id=area.id)
+
+        model = sensor_info.get("model")
+        if group_multi_zone and model and len(get_valve_ports(model)) > 1:
+            for port in get_valve_ports(model):
+                zone_device = device_reg.async_get_device(
+                    identifiers={(DOMAIN, zone_device_identifier(mid, addr, port))}
+                )
+                if zone_device and zone_device.area_id is None:
+                    device_reg.async_update_device(zone_device.id, area_id=area.id)

--- a/custom_components/homgar/manifest.json
+++ b/custom_components/homgar/manifest.json
@@ -13,5 +13,5 @@
         "custom_components.homgar"
     ],
     "requirements": ["paho-mqtt>=1.6.0"],
-    "version": "3.0.38"
+    "version": "3.0.39"
 }

--- a/docs/superpowers/specs/2026-07-04-area-recreated-on-reload-design.md
+++ b/docs/superpowers/specs/2026-07-04-area-recreated-on-reload-design.md
@@ -1,0 +1,98 @@
+# Fix: "My Home" area recreated after integration reload (#70)
+
+## Problem
+
+A user who deletes the HomGar-created "My Home" area in Home Assistant finds it
+recreated (and devices re-homed into it) after every reload of the integration.
+
+Reported in #70. Related to but distinct from #63:
+
+- **#63** (fixed in 3.0.37): a device manually moved to a *different* (non-null)
+  area was reverted. Guard added: only assign when `area_id is None`.
+- **#70**: deleting an area in HA nulls `area_id` on every device that was in it.
+  That null re-triggers the "unseeded, please assign" path in
+  `_assign_devices_to_areas`, which then `async_create`s the area again and
+  reassigns the devices. The #63 guard does not help because the state genuinely
+  is `area_id is None`.
+
+## Root cause
+
+`_assign_devices_to_areas` (`custom_components/homgar/__init__.py`) runs ~2s after
+*every* setup/reload (via `_async_finalize_device_layout`). It explicitly:
+
+```python
+area = area_reg.async_get_area_by_name(home_name)
+if not area:
+    area = area_reg.async_create(home_name)   # recreates a deleted area
+...
+if device.area_id is None:
+    device.area_id = area.id                  # re-homes the device
+```
+
+This is the **only** vector that resurrects a deleted area on reload. `suggested_area`
+in `DeviceInfo` (present across the platforms and `_ensure_device_registry_parents`)
+is **not** a reload vector: HA applies `suggested_area` only at initial device
+*creation* (`device is None`), never re-applying it to an existing device whose
+`area_id` was nulled. (`suggested_area` is separately deprecated and breaks in HA
+2026.9 — tracked as a separate issue, out of scope here.)
+
+## Design
+
+**Rule:** the integration seeds areas only on the **first setup** of a config entry.
+After that it never creates or (re)assigns areas.
+
+### First-setup detection (no persistence)
+
+At the top of `async_setup_entry`, before any devices are created:
+
+```python
+is_first_setup = not dr.async_get(hass).async_entries_for_config_entry(entry.entry_id)
+```
+
+Stash the boolean in `entry_data` so the delayed `_assign_devices_to_areas` reads it.
+
+| Scenario | Device registry at setup start | `is_first_setup` | Area seeding |
+|---|---|---|---|
+| Fresh install | empty | True | seed + assign |
+| Reload / HA restart | populated | False | skip |
+| Delete area, then reload | populated | False | skip (stays gone) |
+| Remove & re-add integration | empty (deleted with entry) | True | re-seed |
+
+No `Store` and no `entry.data` writes — avoids the reload loop that
+`entry.add_update_listener(async_reload_entry)` (line 236) would otherwise cause.
+
+### What changes in `_assign_devices_to_areas`
+
+Gate on `is_first_setup`:
+
+- **Gated (first setup only):** area creation (`async_create`), hub `area_id`
+  assignment, sensor area creation + assignment, zone child-device assignment.
+- **Unconditional (every reload):** hub device **name/model backfill** (the #63
+  backfill) must keep running.
+
+Concretely: if `not is_first_setup`, skip all area create/assign work but still run
+the name/model backfill in the hub loop; return early before the sensor/zone loops.
+
+### New devices on an existing install
+
+Still auto-grouped: a newly discovered physical device is *created* in the registry
+with `suggested_area`, which HA honors at creation time. (This stops working when
+2026.9 removes `suggested_area`; handled by the separate deprecation issue.)
+
+### Migration for already-affected users
+
+None required. Post-upgrade the area still exists (old code kept recreating it); the
+next reload no longer recreates it, so one final manual delete makes it stay gone.
+
+## Testing
+
+Unit test in the existing `tests/run_*.py` style:
+
+- `is_first_setup=False` + a device with `area_id is None` → no `async_create`, no
+  area assignment.
+- `is_first_setup=False` + hub device missing name/model → backfill still applied.
+- `is_first_setup=True` + no existing area → area created and device assigned.
+
+## Out of scope
+
+- Removing `suggested_area` ahead of the HA 2026.9 deprecation (separate issue).

--- a/scripts/pre-commit-docker-test.sh
+++ b/scripts/pre-commit-docker-test.sh
@@ -210,6 +210,16 @@ else
     exit 1
 fi
 
+# ── Test: area seeding regressions ────────────────────────────────────────
+echo "🧪 Running area seeding regression tests..."
+docker cp tests/run_area_seeding_tests.py ha-test:/tmp/tests/run_area_seeding_tests.py > /dev/null
+if docker exec ha-test python3 /tmp/tests/run_area_seeding_tests.py; then
+    echo "✅ Area seeding regression tests passed"
+else
+    echo "❌ ERROR: Area seeding regression tests failed"
+    exit 1
+fi
+
 # ── Test: MQTT parser regressions ─────────────────────────────────────────
 echo "🧪 Running MQTT parser regression tests..."
 docker cp tests/run_mqtt_parser_tests.py ha-test:/tmp/tests/run_mqtt_parser_tests.py > /dev/null

--- a/tests/run_area_seeding_tests.py
+++ b/tests/run_area_seeding_tests.py
@@ -18,13 +18,18 @@ from pathlib import Path
 
 
 def _find_repo_root() -> Path:
-    current = Path(__file__).resolve().parent
-    while True:
-        if (current / "custom_components" / "homgar" / "__init__.py").exists():
-            return current
-        if current.parent == current:
-            raise RuntimeError("Could not locate repository root")
-        current = current.parent
+    # Candidates cover both host runs (repo checkout) and the ha-test container,
+    # where the integration is deployed under /config.
+    candidates = [Path(__file__).resolve().parent, Path.cwd(), Path("/config")]
+    for start in candidates:
+        current = start
+        while True:
+            if (current / "custom_components" / "homgar" / "areas.py").exists():
+                return current
+            if current.parent == current:
+                break
+            current = current.parent
+    raise RuntimeError("Could not locate repository root containing custom_components/homgar")
 
 
 ROOT = _find_repo_root()

--- a/tests/run_area_seeding_tests.py
+++ b/tests/run_area_seeding_tests.py
@@ -1,0 +1,224 @@
+"""Regression tests for area seeding (issues #63 and #70).
+
+`seed_device_areas` must:
+
+- On a RELOAD (``is_first_setup=False``) never (re)create an area or assign a
+  device to one. A user who deletes the HomGar-created "My Home" area finds their
+  device's ``area_id`` nulled by HA; recreating it on the next reload is the #70
+  bug. Reloads still backfill missing device name/model (the #63 behaviour).
+- On FIRST setup (``is_first_setup=True``) create the per-home area and seed
+  devices that have no area yet.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def _find_repo_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while True:
+        if (current / "custom_components" / "homgar" / "__init__.py").exists():
+            return current
+        if current.parent == current:
+            raise RuntimeError("Could not locate repository root")
+        current = current.parent
+
+
+ROOT = _find_repo_root()
+
+
+def _load_module(module_name: str, relative_path: str):
+    path = ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load module from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# --- Stub the HA registry helpers that areas.py lazily imports ---------------
+_ha = types.ModuleType("homeassistant")
+_ha_helpers = types.ModuleType("homeassistant.helpers")
+_ar_mod = types.ModuleType("homeassistant.helpers.area_registry")
+_dr_mod = types.ModuleType("homeassistant.helpers.device_registry")
+
+# The fakes are injected per-test via these module-level globals.
+_ar_mod.async_get = lambda hass: hass["area_reg"]
+_dr_mod.async_get = lambda hass: hass["device_reg"]
+
+sys.modules["homeassistant"] = _ha
+sys.modules["homeassistant.helpers"] = _ha_helpers
+sys.modules["homeassistant.helpers.area_registry"] = _ar_mod
+sys.modules["homeassistant.helpers.device_registry"] = _dr_mod
+
+# Package scaffolding so areas.py's ``from .const import ...`` resolves.
+sys.modules.setdefault("custom_components", types.ModuleType("custom_components"))
+sys.modules.setdefault("custom_components.homgar", types.ModuleType("custom_components.homgar"))
+_load_module("custom_components.homgar.const", "custom_components/homgar/const.py")
+_load_module("custom_components.homgar.decoder", "custom_components/homgar/decoder.py")
+areas = _load_module("custom_components.homgar.areas", "custom_components/homgar/areas.py")
+
+
+PASS = 0
+FAIL = 0
+
+
+def check(name: str, condition: bool, detail: str = "") -> None:
+    global PASS, FAIL
+    if condition:
+        print(f"  ✅ {name}")
+        PASS += 1
+    else:
+        print(f"  ❌ {name}{': ' + detail if detail else ''}")
+        FAIL += 1
+
+
+# --- Fakes -------------------------------------------------------------------
+class FakeArea:
+    def __init__(self, area_id: str, name: str):
+        self.id = area_id
+        self.name = name
+
+
+class FakeAreaRegistry:
+    def __init__(self):
+        self._by_name: dict[str, FakeArea] = {}
+        self.created: list[str] = []
+
+    def async_get_area_by_name(self, name):
+        return self._by_name.get(name)
+
+    def async_create(self, name):
+        area = FakeArea(f"area_{name}", name)
+        self._by_name[name] = area
+        self.created.append(name)
+        return area
+
+    def seed_existing(self, name):
+        self._by_name[name] = FakeArea(f"area_{name}", name)
+
+
+class FakeDevice:
+    def __init__(self, device_id, identifiers, area_id=None, name="", model=""):
+        self.id = device_id
+        self.identifiers = identifiers
+        self.area_id = area_id
+        self.name = name
+        self.model = model
+
+
+class FakeDeviceRegistry:
+    def __init__(self, devices):
+        self._devices = list(devices)
+        self.updates: list[tuple[str, dict]] = []
+
+    def async_get_device(self, identifiers):
+        for d in self._devices:
+            if d.identifiers == identifiers:
+                return d
+        return None
+
+    def async_update_device(self, device_id, **kwargs):
+        self.updates.append((device_id, kwargs))
+        for d in self._devices:
+            if d.id == device_id:
+                for k, v in kwargs.items():
+                    setattr(d, k, v)
+
+
+class FakeEntry:
+    def __init__(self, options=None):
+        self.options = options or {}
+
+
+class FakeCoordinator:
+    def __init__(self, data):
+        self.data = data
+
+
+DOMAIN = "homgar"
+
+
+def _hub_identifiers(mid):
+    return {(DOMAIN, f"rainpoint_hub_{mid}")}
+
+
+# --- Tests -------------------------------------------------------------------
+def _test_reload_does_not_recreate_deleted_area():
+    """#70: on reload, a hub whose area was deleted (area_id=None) is left alone."""
+    area_reg = FakeAreaRegistry()  # user deleted "My Home" -> registry empty
+    hub = FakeDevice("hub1", _hub_identifiers(10), area_id=None, name="Hub", model="HWG")
+    device_reg = FakeDeviceRegistry([hub])
+    hass = {"area_reg": area_reg, "device_reg": device_reg}
+    coord = FakeCoordinator({"hubs": [{"mid": 10, "homeName": "My Home"}], "sensors": {}})
+
+    areas.seed_device_areas(hass, FakeEntry(), coord, is_first_setup=False)
+
+    check("reload does not create the deleted area", area_reg.created == [], str(area_reg.created))
+    check("reload leaves hub area_id None", hub.area_id is None, f"area_id={hub.area_id}")
+
+
+def _test_reload_still_backfills_name_and_model():
+    """#63: name/model backfill keeps running on reload even though area work is gated."""
+    area_reg = FakeAreaRegistry()
+    hub = FakeDevice("hub1", _hub_identifiers(10), area_id=None, name="", model="")
+    device_reg = FakeDeviceRegistry([hub])
+    hass = {"area_reg": area_reg, "device_reg": device_reg}
+    coord = FakeCoordinator(
+        {"hubs": [{"mid": 10, "homeName": "My Home", "name": "My Hub", "model": "HWG0538WRF"}], "sensors": {}}
+    )
+
+    areas.seed_device_areas(hass, FakeEntry(), coord, is_first_setup=False)
+
+    check("reload backfills hub name", hub.name == "My Hub", f"name={hub.name!r}")
+    check("reload backfills hub model", hub.model == "HWG0538WRF", f"model={hub.model!r}")
+    check("reload backfill still does not touch area", hub.area_id is None and area_reg.created == [])
+
+
+def _test_first_setup_creates_and_assigns_area():
+    """Fresh install seeds the per-home area and assigns the hub to it."""
+    area_reg = FakeAreaRegistry()
+    hub = FakeDevice("hub1", _hub_identifiers(10), area_id=None, name="Hub", model="HWG")
+    device_reg = FakeDeviceRegistry([hub])
+    hass = {"area_reg": area_reg, "device_reg": device_reg}
+    coord = FakeCoordinator({"hubs": [{"mid": 10, "homeName": "My Home"}], "sensors": {}})
+
+    areas.seed_device_areas(hass, FakeEntry(), coord, is_first_setup=True)
+
+    check("first setup creates the area", area_reg.created == ["My Home"], str(area_reg.created))
+    check("first setup assigns hub to area", hub.area_id == "area_My Home", f"area_id={hub.area_id}")
+
+
+def _test_reload_does_not_assign_sensor_devices():
+    """#70: on reload, sensor/controller devices with no area are not assigned."""
+    area_reg = FakeAreaRegistry()
+    sensor_dev = FakeDevice("s1", {(DOMAIN, "10_2")}, area_id=None, name="Valve", model="HTV0535FRF")
+    device_reg = FakeDeviceRegistry([sensor_dev])
+    hass = {"area_reg": area_reg, "device_reg": device_reg}
+    coord = FakeCoordinator(
+        {"hubs": [], "sensors": {"s": {"mid": 10, "addr": 2, "home_name": "My Home", "model": "HTV0535FRF"}}}
+    )
+
+    areas.seed_device_areas(hass, FakeEntry(), coord, is_first_setup=False)
+
+    check("reload does not create area for sensors", area_reg.created == [], str(area_reg.created))
+    check("reload leaves sensor area_id None", sensor_dev.area_id is None, f"area_id={sensor_dev.area_id}")
+
+
+def main() -> int:
+    print("Area seeding regression tests (#63, #70)")
+    _test_reload_does_not_recreate_deleted_area()
+    _test_reload_still_backfills_name_and_model()
+    _test_first_setup_creates_and_assigns_area()
+    _test_reload_does_not_assign_sensor_devices()
+    print(f"\n{PASS} passed, {FAIL} failed")
+    return 1 if FAIL else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Fixes #70.

## Problem

A user who deletes the HomGar-created "My Home" area in Home Assistant finds it recreated — and their devices re-homed into it — after every reload of the integration.

Related to but distinct from #63 (fixed in 3.0.37): that fix stopped the integration overwriting a device moved to a *different* (non-null) area. #70 slips through because **deleting an area nulls `area_id` on every device that was in it**, and `_assign_devices_to_areas` read `area_id is None` as "unseeded, please assign" — so on the next reload it called `async_create` for the deleted area and re-homed the devices.

`_assign_devices_to_areas` ran ~2s after *every* setup/reload, so the area came back every time.

## Fix

Area creation and assignment now happen **only on the first setup** of a config entry:

- Extracted the logic into `custom_components/homgar/areas.py` as `seed_device_areas(hass, entry, coordinator, is_first_setup)`.
- `is_first_setup` is detected in `async_setup_entry` *before any devices are created this cycle* — an empty device registry for the entry means a fresh install:
  ```python
  is_first_setup = not dr.async_entries_for_config_entry(dr.async_get(hass), entry.entry_id)
  ```
- On reloads, all area create/assign work is skipped, so a user-deleted area stays deleted.
- **Device name/model backfill still runs on every reload** (the #63 behaviour) — only the area work is gated.
- New devices added to an existing install are still grouped into their home area via `suggested_area` at the moment they are first registered.

No persistence / `Store` is needed, which avoids a reload loop from the entry's `add_update_listener(async_reload_entry)`.

### Why `suggested_area` isn't the culprit
Confirmed against HA 2026.7 `device_registry`: `suggested_area` is applied only at initial device *creation* (`device is None`), never re-applied to an existing device whose `area_id` was nulled. (It's separately deprecated, breaking in HA 2026.9 — tracked separately, out of scope here.)

### Migration
None needed. Post-upgrade the area still exists (old code kept recreating it); the next reload no longer recreates it, so one final manual delete makes it stay gone.

## Tests

New `tests/run_area_seeding_tests.py` (9 assertions) drives the real `seed_device_areas` with fake registries:

- reload does **not** recreate a deleted area or re-assign the hub
- reload **still** backfills missing name/model
- first setup creates the area and assigns the hub
- reload does **not** assign sensor/controller devices

Full local suite green under Python 3.12 (one unrelated test is CI-only — it needs `aiohttp`/HA installed).

Design spec: `docs/superpowers/specs/2026-07-04-area-recreated-on-reload-design.md`
