### PR TITLE
Add scheduled-watering blueprint + next-watering docs (#67)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,67 @@ Adjust entity IDs (e.g. `sensor.your_device_soil_moisture`, `switch.your_irrigat
 ### Water usage tracking
 Track daily/weekly water usage and optimise irrigation over time.
 
+### Scheduled watering — let Home Assistant own the timing
+
+Home Assistant already has a first‑class scheduler (the **Schedule** helper), so this integration deliberately doesn't try to reimplement the app's timers. Instead, drive your valves from a Schedule and you get the best of both worlds: any recurrence HA supports, plus a **"next watering"** time you can use in *other* automations (close the blinds, pull in the washing, send a heads‑up).
+
+A ready‑made blueprint is included:
+
+[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Fbrettmeyerowitz%2Fhomeassistant-homgar%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Fhomgar%2Fscheduled_watering.yaml)
+
+**Setup:**
+1. Create a **Schedule** helper (Settings → Devices & Services → Helpers → **Schedule**) and draw the blocks when you want to water — the length of each block is the watering duration.
+2. Import the blueprint (button above), then create an automation from it and pick your **Schedule** and **valve** (optionally a rain‑skip binary sensor).
+3. Turn off the equivalent schedule in the RainPoint/HomGar app so the two don't both fire.
+
+The valve **opens** when the schedule turns on and **closes** when it turns off. Closing is always safe and survives an HA restart mid‑run better than a fixed delay.
+
+> **Failsafe tip:** also set the valve's **Duration** number entity to your run length. Then the device stops on its own even if Home Assistant happens to be offline when the block ends.
+
+**Rain‑skip sensor** — the blueprint's optional rain‑skip expects a `binary_sensor` (on = wet), but a RainPoint rain sensor reports precipitation as regular `sensor` entities (`…_rain_last_hour`, `…_rain_last_24h`). Turn one into a wet/dry `binary_sensor` with a template:
+
+```yaml
+template:
+  - binary_sensor:
+      - name: Recent rain
+        unique_id: recent_rain
+        device_class: moisture   # on = wet
+        state: >
+          {{ states('sensor.your_rain_sensor_rain_last_hour') | float(0) > 0 }}
+```
+
+Then pick `binary_sensor.recent_rain` as the blueprint's rain‑skip input. Point it at `…_rain_last_24h` (and/or a threshold like `> 1`) if you'd rather skip watering for a day after meaningful rain. You can equally use any weather integration's rain `binary_sensor`.
+
+**Expose "next watering" as a sensor** (great for pre‑emptive automations and dashboards) — the Schedule helper already knows it via `next_event`:
+
+```yaml
+template:
+  - sensor:
+      - name: Next watering
+        unique_id: next_watering
+        device_class: timestamp
+        state: "{{ state_attr('schedule.watering', 'next_event') }}"
+```
+
+Replace `schedule.watering` with your own Schedule helper's entity id (e.g. `schedule.scheduler`). After adding it, restart Home Assistant or reload template entities (Developer Tools → YAML → **Template entities**), then find it under Developer Tools → States → `sensor.next_watering`. It reads `unknown` for a second or two at startup until the schedule initialises, then shows the next start time (and renders as a friendly "in X hours" on a dashboard).
+
+**Example — close the blinds 5 minutes before watering:**
+
+```yaml
+alias: Close blinds before watering
+trigger:
+  - platform: template
+    value_template: >
+      {{ states('sensor.next_watering') not in ('unknown', 'unavailable')
+         and 0 <= (as_timestamp(states('sensor.next_watering')) - as_timestamp(now())) <= 300 }}
+action:
+  - service: cover.close_cover
+    target:
+      entity_id: cover.your_blinds
+```
+
+Adjust `schedule.watering`, `sensor.next_watering`, and `cover.your_blinds` to match your setup.
+
 ## Example dashboard
 
 A simple control panel combining valve control and live sensor data:

--- a/blueprints/automation/homgar/scheduled_watering.yaml
+++ b/blueprints/automation/homgar/scheduled_watering.yaml
@@ -1,0 +1,90 @@
+blueprint:
+  name: HomGar/RainPoint – Scheduled watering
+  description: >
+    Water a HomGar/RainPoint valve on a Home Assistant **Schedule**, with an
+    optional rain‑skip.
+
+
+    Scheduling lives in Home Assistant, not in this blueprint — so you get all of
+    HA's flexibility (any recurrence, conditions, weather, moisture) *and* the
+    Schedule helper's `next_event` attribute becomes your "next watering" time,
+    ready to use in other automations (close the blinds, send a notification,
+    etc.). See the integration README for a ready‑made `next_watering` sensor.
+
+
+    How it works: the valve **opens** when the schedule turns on and **closes**
+    when it turns off, so the length of each schedule block is the watering
+    duration. Closing is always safe, and it survives a Home Assistant restart
+    mid‑run better than a fixed delay.
+
+
+    Tip: also set the valve's **Duration** number entity as a failsafe, so the
+    device still stops on its own even if Home Assistant is offline.
+  domain: automation
+  homeassistant:
+    min_version: "2024.6.0"
+  source_url: https://github.com/brettmeyerowitz/homeassistant-homgar/blob/main/blueprints/automation/homgar/scheduled_watering.yaml
+  input:
+    watering_schedule:
+      name: Watering schedule
+      description: >
+        A Schedule helper that defines when (and for how long) to water. Create
+        one under Settings → Devices & Services → Helpers → Schedule.
+      selector:
+        entity:
+          filter:
+            - domain: schedule
+    valve:
+      name: Valve
+      description: The HomGar/RainPoint valve to open and close.
+      selector:
+        entity:
+          filter:
+            - domain: valve
+              integration: homgar
+    rain_sensor:
+      name: Rain‑skip sensor (optional)
+      description: >
+        Optional. If set and this binary sensor is on (wet) when the schedule
+        starts, that watering run is skipped. Works well with a RainPoint rain
+        sensor or any weather/rain binary sensor.
+      default:
+      selector:
+        entity:
+          filter:
+            - domain: binary_sensor
+
+mode: single
+max_exceeded: silent
+
+trigger:
+  - platform: state
+    entity_id: !input watering_schedule
+    to: "on"
+    id: start
+  - platform: state
+    entity_id: !input watering_schedule
+    to: "off"
+    id: stop
+
+variables:
+  rain_sensor: !input rain_sensor
+
+action:
+  - choose:
+      # Schedule block started → open the valve, unless it is raining.
+      - conditions:
+          - condition: trigger
+            id: start
+          - condition: template
+            value_template: >
+              {{ rain_sensor in [none, ''] or is_state(rain_sensor, 'off') }}
+        sequence:
+          - service: valve.open_valve
+            target:
+              entity_id: !input valve
+    # Schedule block ended, or the run was rain‑skipped → make sure it is closed.
+    default:
+      - service: valve.close_valve
+        target:
+          entity_id: !input valve


### PR DESCRIPTION
Addresses #67 (next planned watering).

## Background

@papadi asked for each valve's **next scheduled watering** time, to drive pre-emptive automations (e.g. close blinds before irrigation). I investigated whether that's retrievable and it isn't via the cloud: the schedule lives on-device. I captured full cloud payloads for a valve with an active schedule (`getDeviceByHid`, `getDeviceStatus`, `multipleDeviceStatus`), checked `planJson`/`param`, probed ~60 candidate schedule endpoints (all `9997 no-handler`), and confirmed via a proxy that the app fetches nothing schedule-related over HTTPS — it's on-device/MQTT and would need fragile RE.

## Approach

Rather than reimplement scheduling that Home Assistant already does well, lean on HA's **Schedule** helper. This gives users any recurrence HA supports **and** a "next watering" time for free (the schedule's `next_event`).

## Changes

- **`blueprints/automation/homgar/scheduled_watering.yaml`** — automation blueprint: opens a valve when a Schedule helper turns on, closes it when it turns off (block length = watering duration; closing survives an HA restart mid-run better than a fixed delay), with an optional rain-skip `binary_sensor`.
- **README** — new "Scheduled watering" section: the philosophy (don't duplicate HA scheduling), a My-Home-Assistant import button, a `next_watering` template `sensor`, a template `binary_sensor` to turn a RainPoint precipitation sensor into a rain-skip input, and a pre-watering example automation.

No `custom_components/` changes, so no version bump.

## Testing

Validated end-to-end on a live HA Docker instance with real devices:
- Blueprint parses and instantiates against a real valve + Schedule via `check_config`, both with and without a rain sensor.
- `sensor.next_watering` populates correctly from the schedule's `next_event`.
- `binary_sensor.recent_rain` renders correctly (off when dry).
