### PR TITLE
fix(api): send an app User-Agent — HomGar cloud 403s the "HomeAssistant" UA (#76)

### DIFF
--- a/custom_components/homgar/api/client.py
+++ b/custom_components/homgar/api/client.py
@@ -19,6 +19,15 @@ _LOGGER = logging.getLogger(__name__)
 # whole coordinator cycle for up to 5 minutes during upstream flakiness.
 _REQUEST_TIMEOUT = aiohttp.ClientTimeout(total=30, connect=10, sock_connect=10)
 
+# HomGar's cloud (region3.homgarus.com, plain nginx) returns 403 Forbidden to any
+# request whose User-Agent contains "HomeAssistant". HA's shared aiohttp session
+# stamps "HomeAssistant/<ver> aiohttp/... Python/..." by default, so every call
+# was blocked (login/token-refresh 403 on every coordinator cycle). Send a
+# neutral, app-style User-Agent on every request instead. The block is purely the
+# UA substring — not IP- or TLS-fingerprint-based — so any non-"HomeAssistant"
+# value works; this mirrors the RainPoint/HomGar phone app. See issue #76.
+_USER_AGENT = "okhttp/4.9.2"
+
 
 class HomGarApiError(Exception):
     pass
@@ -59,11 +68,15 @@ class HomGarClient:
     def _get(self, url: str, **kwargs):
         """Issue a GET via the shared session with an explicit timeout."""
         kwargs.setdefault("timeout", _REQUEST_TIMEOUT)
+        # Force the app User-Agent last so it always overrides HA's session default.
+        kwargs["headers"] = {**(kwargs.get("headers") or {}), "User-Agent": _USER_AGENT}
         return self._session.get(url, **kwargs)
 
     def _post(self, url: str, **kwargs):
         """Issue a POST via the shared session with an explicit timeout."""
         kwargs.setdefault("timeout", _REQUEST_TIMEOUT)
+        # Force the app User-Agent last so it always overrides HA's session default.
+        kwargs["headers"] = {**(kwargs.get("headers") or {}), "User-Agent": _USER_AGENT}
         return self._session.post(url, **kwargs)
 
     # --- token state helpers ---


### PR DESCRIPTION
Fixes #76.

**Problem:** `region3.homgarus.com` (plain nginx) returns `403 Forbidden` to any request whose `User-Agent` contains `HomeAssistant`. HA's shared aiohttp session stamps `HomeAssistant/<ver> aiohttp/… Python/…` by default, so **every** call is blocked — login and token-refresh 403 on every coordinator cycle, all entities `unavailable`, while the phone app keeps working.

**Fix:** send a neutral, app-style `User-Agent` (`okhttp/4.9.2`, matching the RainPoint/HomGar app) on every request. `_get`/`_post` are the single request chokepoint (they already inject the timeout), so this one change covers login, auth headers, token refresh, and MQTT credential renewal.

**Evidence:** single-variable repro in #76 — only the UA changes: `HomeAssistant/…` → 403, `curl`/`aiohttp`/`okhttp` defaults → 200. Independently confirmed on both RainPoint (`appCode 2`) and HomGar (`appCode 1`) accounts; the block is a UA substring match, not IP- or TLS-fingerprint-based.

**Scope:** User-Agent only. Two related findings from #76 — the re-auth loop on a non-200 `list_homes`, and the per-cycle static-metadata over-fetching — are left as separate follow-ups.

**Testing:** applied to a live install (RainPoint, `appCode 2`); the 403 loop stopped immediately and all entities recovered.