### PR TITLE
fix(api): send an app User-Agent — HomGar cloud 403s the "HomeAssistant" UA (#75, #76)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.0.40] - 2026-07-24
+
+### 🐛 Bug Fixes
+- **Cloud 403 — send an app User-Agent** — as of ~mid-July 2026 the HomGar cloud (`region3.homgarus.com`, plain nginx) returns `403 Forbidden` to any request whose `User-Agent` contains the substring `HomeAssistant`. Home Assistant's shared aiohttp session (`async_get_clientsession`) stamps `HomeAssistant/<ver> aiohttp/… Python/…` by default, so **every** call was blocked: login and token refresh 403'd on every coordinator cycle, all entities went `unavailable`, while the vendor phone app kept working (making it look like a credentials problem). The client now sends a neutral, app-style `User-Agent` (`okhttp/4.9.2`, matching the RainPoint/HomGar app) on every request, forced in the `_get`/`_post` chokepoint so it covers login, auth headers, token refresh, and MQTT credential renewal. The block is a pure UA substring match (not IP- or TLS-fingerprint-based), verified single-variable against the live cloud: `HomeAssistant/…` → 403, `okhttp/4.9.2` → 200. ([#75](https://github.com/brettmeyerowitz/homeassistant-homgar/issues/75), [#76](https://github.com/brettmeyerowitz/homeassistant-homgar/issues/76), [#77](https://github.com/brettmeyerowitz/homeassistant-homgar/pull/77))
+
+---
+
 ## [3.0.39] - 2026-07-04
 
 ### 🐛 Bug Fixes

--- a/custom_components/homgar/api/client.py
+++ b/custom_components/homgar/api/client.py
@@ -19,6 +19,15 @@ _LOGGER = logging.getLogger(__name__)
 # whole coordinator cycle for up to 5 minutes during upstream flakiness.
 _REQUEST_TIMEOUT = aiohttp.ClientTimeout(total=30, connect=10, sock_connect=10)
 
+# HomGar's cloud (region3.homgarus.com, plain nginx) returns 403 Forbidden to any
+# request whose User-Agent contains "HomeAssistant". HA's shared aiohttp session
+# stamps "HomeAssistant/<ver> aiohttp/... Python/..." by default, so every call
+# was blocked (login/token-refresh 403 on every coordinator cycle). Send a
+# neutral, app-style User-Agent on every request instead. The block is purely the
+# UA substring — not IP- or TLS-fingerprint-based — so any non-"HomeAssistant"
+# value works; this mirrors the RainPoint/HomGar phone app. See issue #76.
+_USER_AGENT = "okhttp/4.9.2"
+
 
 class HomGarApiError(Exception):
     pass
@@ -59,11 +68,15 @@ class HomGarClient:
     def _get(self, url: str, **kwargs):
         """Issue a GET via the shared session with an explicit timeout."""
         kwargs.setdefault("timeout", _REQUEST_TIMEOUT)
+        # Force the app User-Agent last so it always overrides HA's session default.
+        kwargs["headers"] = {**(kwargs.get("headers") or {}), "User-Agent": _USER_AGENT}
         return self._session.get(url, **kwargs)
 
     def _post(self, url: str, **kwargs):
         """Issue a POST via the shared session with an explicit timeout."""
         kwargs.setdefault("timeout", _REQUEST_TIMEOUT)
+        # Force the app User-Agent last so it always overrides HA's session default.
+        kwargs["headers"] = {**(kwargs.get("headers") or {}), "User-Agent": _USER_AGENT}
         return self._session.post(url, **kwargs)
 
     # --- token state helpers ---

--- a/custom_components/homgar/manifest.json
+++ b/custom_components/homgar/manifest.json
@@ -13,5 +13,5 @@
         "custom_components.homgar"
     ],
     "requirements": ["paho-mqtt>=1.6.0"],
-    "version": "3.0.39"
+    "version": "3.0.40"
 }

--- a/scripts/pre-commit-docker-test.sh
+++ b/scripts/pre-commit-docker-test.sh
@@ -280,6 +280,16 @@ else
     exit 1
 fi
 
+# ── Test: User-Agent regressions ──────────────────────────────────────────
+echo "🧪 Running User-Agent regression tests..."
+docker cp tests/run_user_agent_tests.py ha-test:/tmp/tests/run_user_agent_tests.py > /dev/null
+if docker exec ha-test python3 /tmp/tests/run_user_agent_tests.py; then
+    echo "✅ User-Agent regression tests passed"
+else
+    echo "❌ ERROR: User-Agent regression tests failed"
+    exit 1
+fi
+
 # ── Test: decoder regression suite (scripts/test_decoders.py) ─────────────
 echo "🧪 Running decoder regression suite..."
 docker cp scripts/test_decoders.py ha-test:/tmp/test_decoders.py > /dev/null

--- a/tests/run_user_agent_tests.py
+++ b/tests/run_user_agent_tests.py
@@ -1,0 +1,218 @@
+"""Regression tests: every HomGar API request sends an app User-Agent.
+
+As of ~mid-July 2026 the HomGar cloud (``region3.homgarus.com``, plain nginx)
+returns ``403 Forbidden`` to any request whose ``User-Agent`` contains the
+substring ``HomeAssistant``. HA's shared aiohttp session stamps
+``HomeAssistant/<ver> aiohttp/<v> Python/<v>`` by default, so every call was
+blocked. The client forces a neutral app-style UA in the ``_get``/``_post``
+chokepoint. These tests pin that behaviour: the override is present on both
+verbs, it wins over a caller/session-supplied header, it never contains
+``HomeAssistant``, and it does not clobber other caller headers (e.g. ``auth``).
+See issues #75 / #76 and PR #77.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def _find_repo_root() -> Path:
+    candidates = [Path(__file__).resolve().parent, Path.cwd(), Path("/config")]
+    for start in candidates:
+        current = start
+        while True:
+            if (current / "custom_components" / "homgar" / "api" / "client.py").exists():
+                return current
+            if current.parent == current:
+                break
+            current = current.parent
+    raise RuntimeError("Could not locate repository root containing custom_components/homgar")
+
+
+ROOT = _find_repo_root()
+
+
+def _load_module(module_name: str, relative_path: str):
+    path = ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load module from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# --- Minimal aiohttp stub (aiohttp is not a test-env dependency) -------------
+
+
+class _ClientTimeout:
+    def __init__(self, total=None, connect=None, sock_connect=None, sock_read=None):
+        self.total = total
+        self.connect = connect
+        self.sock_connect = sock_connect
+        self.sock_read = sock_read
+
+
+class _ClientSession:  # only needed for the type annotation in __init__
+    pass
+
+
+_aiohttp_stub = types.ModuleType("aiohttp")
+_aiohttp_stub.ClientTimeout = _ClientTimeout
+_aiohttp_stub.ClientSession = _ClientSession
+_aiohttp_stub.ClientError = type("ClientError", (Exception,), {})
+sys.modules["aiohttp"] = _aiohttp_stub
+
+sys.modules.setdefault("custom_components", types.ModuleType("custom_components"))
+sys.modules.setdefault("custom_components.homgar", types.ModuleType("custom_components.homgar"))
+sys.modules.setdefault("custom_components.homgar.api", types.ModuleType("custom_components.homgar.api"))
+_load_module("custom_components.homgar.const", "custom_components/homgar/const.py")
+client_mod = _load_module("custom_components.homgar.api.client", "custom_components/homgar/api/client.py")
+
+
+PASS = 0
+FAIL = 0
+
+
+def check(name: str, condition: bool, detail: str = "") -> None:
+    global PASS, FAIL
+    if condition:
+        print(f"  ✅ {name}")
+        PASS += 1
+    else:
+        print(f"  ❌ {name}{': ' + detail if detail else ''}")
+        FAIL += 1
+
+
+class _FakeResp:
+    def __init__(self, payload):
+        self._payload = payload
+        self.status = 200
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def json(self):
+        return self._payload
+
+    async def text(self):
+        return ""
+
+
+class _RecordingSession:
+    """Records the ``headers`` kwarg passed to each get/post call."""
+
+    def __init__(self, payload):
+        self._payload = payload
+        self.calls: list[tuple[str, str, dict]] = []  # (method, url, headers)
+
+    def get(self, url, **kwargs):
+        self.calls.append(("get", url, kwargs.get("headers") or {}))
+        return _FakeResp(self._payload)
+
+    def post(self, url, **kwargs):
+        self.calls.append(("post", url, kwargs.get("headers") or {}))
+        return _FakeResp(self._payload)
+
+
+def _make_client(payload):
+    session = _RecordingSession(payload)
+    client = client_mod.HomGarClient("31", "a@b.com", "pw", session, "homgar")
+    return client, session
+
+
+_APP_UA = "okhttp/4.9.2"
+
+
+def _test_user_agent_constant():
+    ua = getattr(client_mod, "_USER_AGENT", None)
+    check("client exposes _USER_AGENT", ua is not None, "constant missing")
+    check("_USER_AGENT is the app UA (okhttp/4.9.2)", ua == _APP_UA, f"got {ua!r}")
+    check(
+        "_USER_AGENT does not contain 'HomeAssistant'",
+        ua is not None and "HomeAssistant" not in ua,
+        f"got {ua!r}",
+    )
+
+
+async def _test_login_post_sets_ua():
+    payload = {
+        "code": 0,
+        "ts": 1700000000000,
+        "data": {"token": "tok", "refreshToken": "r", "tokenExpired": 3600, "user": {}},
+    }
+    client, session = _make_client(payload)
+    ok = await client.login()
+    check("login() succeeds against fake server", ok is True)
+    post_calls = [c for c in session.calls if c[0] == "post"]
+    check("login issues a POST", len(post_calls) == 1, str(session.calls))
+    hdrs = post_calls[0][2] if post_calls else {}
+    check(
+        "login POST sends the app User-Agent",
+        hdrs.get("User-Agent") == _APP_UA,
+        f"got {hdrs.get('User-Agent')!r}",
+    )
+    # login() supplies its own headers (Content-Type/lang/appCode); ensure they survive.
+    check(
+        "login POST preserves caller headers (appCode)",
+        hdrs.get("appCode") == "1",
+        f"headers={hdrs}",
+    )
+
+
+async def _test_get_path_sets_ua():
+    payload = {"code": 0, "data": [], "ts": 1700000000000}
+    client, session = _make_client(payload)
+    client._token = "tok"
+    from datetime import datetime, timedelta, timezone
+
+    client._token_expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
+    await client.list_homes()
+    get_calls = [c for c in session.calls if c[0] == "get"]
+    check("list_homes issues a GET", len(get_calls) == 1, str(session.calls))
+    hdrs = get_calls[0][2] if get_calls else {}
+    check(
+        "list_homes GET sends the app User-Agent",
+        hdrs.get("User-Agent") == _APP_UA,
+        f"got {hdrs.get('User-Agent')!r}",
+    )
+
+
+async def _test_ua_overrides_caller_header():
+    """A caller/session default of a HomeAssistant UA must be overridden."""
+    payload = {"code": 0, "data": [], "ts": 1700000000000}
+    client, session = _make_client(payload)
+    # Directly exercise the chokepoint with a hostile caller header. _post returns
+    # the (async) response object; we only care about what headers it recorded.
+    client._post(
+        "https://example/test",
+        headers={"User-Agent": "HomeAssistant/2026.7 aiohttp/3 Python/3.13", "auth": "T"},
+    )
+    _, _, hdrs = session.calls[-1]
+    check(
+        "_post overrides a HomeAssistant User-Agent with the app UA",
+        hdrs.get("User-Agent") == _APP_UA,
+        f"got {hdrs.get('User-Agent')!r}",
+    )
+    check("_post preserves other caller headers (auth)", hdrs.get("auth") == "T", f"headers={hdrs}")
+
+
+def main() -> int:
+    print("User-Agent regression tests")
+    _test_user_agent_constant()
+    asyncio.run(_test_login_post_sets_ua())
+    asyncio.run(_test_get_path_sets_ua())
+    asyncio.run(_test_ua_overrides_caller_header())
+    print(f"\n{PASS} passed, {FAIL} failed")
+    return 1 if FAIL else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Addresses #75 and #76 — intentionally **not** using auto-close keywords; the issues stay open until this is verified live in a HACS release. Supersedes #77 (same one-line fix, plus version bump, changelog, and a regression suite).

## Problem
As of ~mid-July 2026, `region3.homgarus.com` (plain nginx) returns `403 Forbidden` to any request whose `User-Agent` contains the substring `HomeAssistant`. HA's shared aiohttp session (`async_get_clientsession`) stamps `HomeAssistant/<ver> aiohttp/… Python/…` by default, so **every** call is blocked — login and token refresh 403 on every coordinator cycle, all entities go `unavailable` — while the vendor phone app keeps working (making it look like a credentials problem). Reported independently as #75 and #76.

## Fix
Send a neutral, app-style `User-Agent` (`okhttp/4.9.2`, matching the RainPoint/HomGar app) on every request. `_get`/`_post` are the single request chokepoint (they already inject the timeout), so this one change covers login, auth headers, token refresh, and MQTT credential renewal. The app UA is merged **last** so it always overrides HA's session default while preserving any per-call headers (e.g. `auth`).

## Evidence — verified against the live cloud
Single-variable replay of the exact `/auth/basic/app/login` request from inside a Docker HA container, changing **only** the User-Agent:

| User-Agent | Result |
|---|---|
| `HomeAssistant/… aiohttp/… Python/…` | **403** — nginx HTML error page |
| `okhttp/4.9.2` | **200** — `{"code":0,"msg":"SUCCESS"}` (valid token) |

End-to-end through the real integration code: unpatched `login()` → `403`/`False` (bug reproduced); patched → `login() = True`, `Completed platform setup`, entities recover. The block is a pure UA substring match (not IP- or TLS-fingerprint-based).

## Scope
User-Agent only. Two related findings from #76 — the re-auth loop on a non-200 `list_homes`, and per-cycle static-metadata over-fetching — are left as separate follow-ups.

## Changes
- `api/client.py`: `_USER_AGENT = "okhttp/4.9.2"`, forced in `_get`/`_post`.
- `manifest.json`: `3.0.39` → `3.0.40`.
- `CHANGELOG.md`: 3.0.40 entry.
- `tests/run_user_agent_tests.py`: new regression suite (UA present on GET/POST, overrides a `HomeAssistant` header, never contains `HomeAssistant`, preserves other caller headers) — wired into `scripts/pre-commit-docker-test.sh`.

## Testing
Full pre-commit Docker gate passes (live setup + all regression suites, incl. the new UA suite 11/11).

Credit for the diagnosis and fix goes to @3DCreationsByChad (#76).