### PR TITLE
fix(api): recover from rejected tokens on every cloud endpoint + token diagnostic sensors (v3.0.41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,15 @@ All notable changes to this project will be documented in this file.
 - Added `tests/run_token_reauth_tests.py` (23 checks): a `1004`/`1001` on any of the control, subscribe, status, set, and product-model endpoints triggers exactly one fresh login and one retry; a clean response never re-authenticates; and non-token errors still raise. Wired into the pre-commit Docker gate.
 
 ### 🔎 Diagnostics
-- **Token re-auth visibility** — three local-only diagnostic sensors on the Hub device make token re-authentication measurable: `Token re-auth count` (a `total_increasing` value whose history-graph slope shows how often the cloud is rejecting the token), `Last token re-auth` (timestamp, with `trigger_endpoint` and `last_error_code` attributes), and `Token expires at` (a far-future value here means the token is long-lived and any churn is external session invalidation, not expiry). Enabled by default, no data leaves Home Assistant. Find them under Settings → Devices & Services → HomGar/RainPoint → Hub → Diagnostic. To watch the rhythm on one graph:
+- **Token re-auth visibility** — three local-only diagnostic sensors on the Hub device make token re-authentication measurable: `Token re-auth count` (a `total_increasing` value whose history-graph slope shows how often the cloud is rejecting the token), `Last token re-auth` (timestamp, with `trigger_endpoint` and `last_error_code` attributes), and `Token expires at` (a far-future value here means the token is long-lived and any churn is external session invalidation, not expiry). Enabled by default, no data leaves Home Assistant. Find them under Settings → Devices & Services → HomGar/RainPoint → Hub → Diagnostic. To watch the rhythm on one graph, add a history-graph card and pick the three "Token …" sensors from the entity list (their entity IDs are derived from your hub's name, e.g. if the hub is named *Hub* they are `sensor.hub_token_re_auth_count`, `sensor.hub_last_token_re_auth`, `sensor.hub_token_expires_at` — replace with your own):
 
     ```yaml
     type: history-graph
     hours_to_show: 6
     entities:
-      - sensor.homgar_token_reauth_count
-      - sensor.homgar_last_token_reauth
-      - sensor.homgar_token_expires_at
+      - sensor.hub_token_re_auth_count
+      - sensor.hub_last_token_re_auth
+      - sensor.hub_token_expires_at
     ```
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ All notable changes to this project will be documented in this file.
 ### 🧪 Tests
 - Added `tests/run_token_reauth_tests.py` (23 checks): a `1004`/`1001` on any of the control, subscribe, status, set, and product-model endpoints triggers exactly one fresh login and one retry; a clean response never re-authenticates; and non-token errors still raise. Wired into the pre-commit Docker gate.
 
+### 🔎 Diagnostics
+- **Token re-auth visibility** — three local-only diagnostic sensors on the Hub device make token re-authentication measurable: `Token re-auth count` (a `total_increasing` value whose history-graph slope shows how often the cloud is rejecting the token), `Last token re-auth` (timestamp, with `trigger_endpoint` and `last_error_code` attributes), and `Token expires at` (a far-future value here means the token is long-lived and any churn is external session invalidation, not expiry). Enabled by default, no data leaves Home Assistant. Find them under Settings → Devices & Services → HomGar/RainPoint → Hub → Diagnostic. To watch the rhythm on one graph:
+
+    ```yaml
+    type: history-graph
+    hours_to_show: 6
+    entities:
+      - sensor.homgar_token_reauth_count
+      - sensor.homgar_last_token_reauth
+      - sensor.homgar_token_expires_at
+    ```
+
 ---
 
 ## [3.0.40] - 2026-07-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.0.41] - 2026-07-24
+
+### 🐛 Bug Fixes
+- **Every cloud call now recovers from a rejected token** — two related failures surfaced after v3.0.40 let requests reach the cloud again: controlling a valve failed with `controlWorkMode failed: code=1004 msg=token error`, and the MQTT renewal loop got stuck on `subscribeStatus failed: {'code': 1001, 'msg': 'NOT_TOKEN'}`, retrying every 30–300s without ever recovering. Root cause: only the three list/status **read** endpoints re-authenticated and retried once on a server-rejected token; the rest (`controlWorkMode`, `controlWorkModeDP`, `subscribeStatus`, `getDeviceStatus`, `setDeviceStatus`, `productModel`) raised or degraded instead. Because `ensure_logged_in()`/`_ensure_auth()` only check the **local** expiry clock, the cloud can reject a token (rotation, or the refresh path overstating token lifetime) while Home Assistant still believes it is valid — so the coordinator's read cycles silently re-authenticated and kept entities updating, while valve commands threw and the independent MQTT-renewal schedule spun in a `NOT_TOKEN` retry storm. All authenticated endpoints now perform the same `1001/1004 → re-auth → retry once` recovery. Thanks to [@shaundekok](https://github.com/shaundekok) for reporting both symptoms and providing the logs that pinned it down. ([#75](https://github.com/brettmeyerowitz/homeassistant-homgar/issues/75), [#76](https://github.com/brettmeyerowitz/homeassistant-homgar/issues/76))
+
+### 🧪 Tests
+- Added `tests/run_token_reauth_tests.py` (23 checks): a `1004`/`1001` on any of the control, subscribe, status, set, and product-model endpoints triggers exactly one fresh login and one retry; a clean response never re-authenticates; and non-token errors still raise. Wired into the pre-commit Docker gate.
+
+---
+
 ## [3.0.40] - 2026-07-24
 
 ### 🐛 Bug Fixes

--- a/custom_components/homgar/api/client.py
+++ b/custom_components/homgar/api/client.py
@@ -57,6 +57,10 @@ class HomGarClient:
         self._last_reauth_at: datetime | None = None
         self._last_reauth_trigger: str | None = None
         self._last_reauth_code: int | None = None
+        # Serialises re-authentication so concurrent callers (e.g. a coordinator
+        # poll and the independent MQTT-renewal) that hit a rejected token in the
+        # same window collapse into a single login instead of a re-login storm.
+        self._auth_lock = asyncio.Lock()
 
         # region host: you had region3; we can later make this configurable
         self._base_url = "https://region3.homgarus.com"
@@ -263,20 +267,45 @@ class HomGarClient:
             if not await self.refresh_token():
                 raise HomGarApiError("Authentication failed")
 
-    async def _reauth(self, trigger: str | None = None, code: int | None = None) -> None:
-        """Force a fresh login, invalidating the current token."""
-        self._reauth_count += 1
-        self._last_reauth_at = datetime.now(timezone.utc)
-        self._last_reauth_trigger = trigger
-        self._last_reauth_code = code
-        _LOGGER.info(
-            "HomGar: token rejected by server (trigger=%s code=%s), forcing fresh login (reauth #%d)",
-            trigger, code, self._reauth_count,
-        )
-        self._token = None
-        self._token_expires_at = None
-        if not await self.login():
-            raise HomGarApiError("Re-authentication failed")
+    async def _reauth(
+        self,
+        trigger: str | None = None,
+        code: int | None = None,
+        rejected_token: str | None = None,
+    ) -> None:
+        """Force a fresh login, invalidating the current token.
+
+        Serialised via ``_auth_lock``. ``rejected_token`` is the token the
+        failing request actually used; if, once we hold the lock, the current
+        token differs from it, a concurrent caller already re-authenticated —
+        reuse that fresh token instead of forcing another login. This collapses a
+        simultaneous coordinator-poll + MQTT-renewal rejection into one login
+        regardless of scheduling order.
+        """
+        async with self._auth_lock:
+            if (
+                rejected_token is not None
+                and self._token is not None
+                and self._token != rejected_token
+            ):
+                _LOGGER.debug(
+                    "HomGar: token already refreshed by a concurrent call "
+                    "(trigger=%s code=%s); skipping duplicate login",
+                    trigger, code,
+                )
+                return
+            self._reauth_count += 1
+            self._last_reauth_at = datetime.now(timezone.utc)
+            self._last_reauth_trigger = trigger
+            self._last_reauth_code = code
+            _LOGGER.info(
+                "HomGar: token rejected by server (trigger=%s code=%s), forcing fresh login (reauth #%d)",
+                trigger, code, self._reauth_count,
+            )
+            self._token = None
+            self._token_expires_at = None
+            if not await self.login():
+                raise HomGarApiError("Re-authentication failed")
 
     @property
     def reauth_count(self) -> int:
@@ -305,14 +334,15 @@ class HomGarClient:
         await self.ensure_logged_in()
         url = f"{self._base_url}/app/member/appHome/list"
         _LOGGER.debug("API call: list_homes URL=%s", url)
-        
+
+        used_token = self._token
         async with self._get(url, headers=self._auth_headers()) as resp:
             if resp.status != 200:
                 raise HomGarApiError(f"list_homes HTTP {resp.status}")
             data = await resp.json()
             _LOGGER.debug("API response: list_homes data=%s", data)
         if data.get("code") in (1001, 1004):
-            await self._reauth(trigger="list_homes", code=data.get("code"))
+            await self._reauth(trigger="list_homes", code=data.get("code"), rejected_token=used_token)
             async with self._get(url, headers=self._auth_headers()) as resp2:
                 data = await resp2.json()
         if data.get("code") != 0:
@@ -325,13 +355,14 @@ class HomGarClient:
         url = f"{self._base_url}/app/device/getDeviceByHid"
         params = {"hid": hid}
         _LOGGER.debug("API call: get_devices_by_hid URL=%s params=%s", url, params)
+        used_token = self._token
         async with self._get(url, headers=self._auth_headers(), params=params) as resp:
             if resp.status != 200:
                 raise HomGarApiError(f"getDeviceByHid HTTP {resp.status}")
             data = await resp.json()
         _LOGGER.debug("API response: get_devices_by_hid data=%s", data)
         if data.get("code") in (1001, 1004):
-            await self._reauth(trigger="getDeviceByHid", code=data.get("code"))
+            await self._reauth(trigger="getDeviceByHid", code=data.get("code"), rejected_token=used_token)
             async with self._get(url, headers=self._auth_headers(), params=params) as resp2:
                 data = await resp2.json()
         if data.get("code") != 0:
@@ -354,13 +385,14 @@ class HomGarClient:
         
         payload = {"devices": device_list}
         _LOGGER.debug("API call: get_multiple_device_status URL=%s payload=%s", url, payload)
+        used_token = self._token
         async with self._post(url, headers=self._auth_headers(), json=payload) as resp:
             if resp.status != 200:
                 raise HomGarApiError(f"Failed to get device status: {resp.status}")
             data = await resp.json()
         _LOGGER.debug("API response: get_multiple_device_status data=%s", data)
         if data.get("code") in (1001, 1004):
-            await self._reauth(trigger="multipleDeviceStatus", code=data.get("code"))
+            await self._reauth(trigger="multipleDeviceStatus", code=data.get("code"), rejected_token=used_token)
             async with self._post(url, headers=self._auth_headers(), json=payload) as resp2:
                 data = await resp2.json()
         if data.get("code") != 0:
@@ -385,13 +417,14 @@ class HomGarClient:
         url = f"{self._base_url}/app/device/getDeviceStatus"
         params = {"mid": mid}
         _LOGGER.debug("API call: get_device_status URL=%s params=%s", url, params)
+        used_token = self._token
         async with self._get(url, headers=self._auth_headers(), params=params) as resp:
             if resp.status != 200:
                 raise HomGarApiError(f"getDeviceStatus HTTP {resp.status}")
             data = await resp.json()
         _LOGGER.debug("API response: get_device_status data=%s", data)
         if data.get("code") in (1001, 1004):
-            await self._reauth(trigger="getDeviceStatus", code=data.get("code"))
+            await self._reauth(trigger="getDeviceStatus", code=data.get("code"), rejected_token=used_token)
             async with self._get(url, headers=self._auth_headers(), params=params) as resp2:
                 if resp2.status != 200:
                     raise HomGarApiError(f"getDeviceStatus HTTP {resp2.status}")
@@ -448,6 +481,7 @@ class HomGarClient:
             },
         }
         _LOGGER.debug("API call: subscribe_status URL=%s payload=%s", url, payload)
+        used_token = self._token
         async with self._post(url, headers=self._auth_headers(), json=payload) as resp:
             if resp.status != 200:
                 raise HomGarApiError(f"subscribeStatus HTTP {resp.status}")
@@ -457,7 +491,7 @@ class HomGarClient:
         # renewal in a retry storm, since ensure_auth only checks the local clock.
         # Re-auth and retry once, as the read endpoints do.
         if data.get("code") in (1001, 1004):
-            await self._reauth(trigger="subscribeStatus", code=data.get("code"))
+            await self._reauth(trigger="subscribeStatus", code=data.get("code"), rejected_token=used_token)
             async with self._post(url, headers=self._auth_headers(), json=payload) as resp2:
                 if resp2.status != 200:
                     raise HomGarApiError(f"subscribeStatus HTTP {resp2.status}")
@@ -478,12 +512,13 @@ class HomGarClient:
             "productKey": product_key,
             "status": state,
         }
+        used_token = self._token
         async with self._post(url, headers=self._auth_headers(), json=payload) as resp:
             if resp.status != 200:
                 raise HomGarApiError(f"Failed to set device state: {resp.status}")
             data = await resp.json()
         if data.get("code") in (1001, 1004):
-            await self._reauth(trigger="setDeviceStatus", code=data.get("code"))
+            await self._reauth(trigger="setDeviceStatus", code=data.get("code"), rejected_token=used_token)
             async with self._post(url, headers=self._auth_headers(), json=payload) as resp2:
                 if resp2.status != 200:
                     raise HomGarApiError(f"Failed to set device state: {resp2.status}")
@@ -502,15 +537,16 @@ class HomGarClient:
         params = {"version": version}
         
         _LOGGER.debug("API call: get_product_models URL=%s params=%s", url, params)
+        used_token = self._token
         async with self._get(url, headers=self._auth_headers(), params=params) as resp:
             if resp.status != 200:
                 raise HomGarApiError(f"2026-04-10 21:22:21.337 DEBUG (MainThread) [custom_components.homgar.api.client] API call: get_product_models URL=https://region3.homgarus.com/app/common/core/productModel params={'version': 0} HTTP {resp.status}")
             data = await resp.json()
-        
+
         _LOGGER.warning("API response: get_product_models received, code=%s", data.get('code'))
 
         if isinstance(data, dict) and data.get("code") in (1001, 1004):
-            await self._reauth(trigger="productModel", code=data.get("code"))
+            await self._reauth(trigger="productModel", code=data.get("code"), rejected_token=used_token)
             async with self._get(url, headers=self._auth_headers(), params=params) as resp2:
                 if resp2.status != 200:
                     raise HomGarApiError(f"get_product_models HTTP {resp2.status}")
@@ -620,6 +656,7 @@ class HomGarClient:
             payload["hid"] = str(hid)
         _LOGGER.debug("API call: control_work_mode URL=%s payload=%s", url, payload)
 
+        used_token = self._token
         async with self._post(url, json=payload, headers=self._auth_headers()) as resp:
             if resp.status != 200:
                 raise HomGarApiError(f"controlWorkMode HTTP {resp.status}")
@@ -633,7 +670,7 @@ class HomGarClient:
         # succeed. Surfaced once the #75/#76 User-Agent fix let control calls
         # actually reach the cloud.
         if data.get("code") in (1001, 1004):
-            await self._reauth(trigger="controlWorkMode", code=data.get("code"))
+            await self._reauth(trigger="controlWorkMode", code=data.get("code"), rejected_token=used_token)
             async with self._post(url, json=payload, headers=self._auth_headers()) as resp2:
                 if resp2.status != 200:
                     raise HomGarApiError(f"controlWorkMode HTTP {resp2.status}")
@@ -684,6 +721,7 @@ class HomGarClient:
 
         _LOGGER.debug("API call: control_work_mode_dp URL=%s payload=%s", url, payload)
 
+        used_token = self._token
         async with self._post(url, json=payload, headers=headers) as resp:
             if resp.status != 200:
                 raise HomGarApiError(f"controlWorkModeDP HTTP {resp.status}")
@@ -697,7 +735,7 @@ class HomGarClient:
         # succeed. Surfaced once the #75/#76 User-Agent fix let control calls
         # actually reach the cloud.
         if data.get("code") in (1001, 1004):
-            await self._reauth(trigger="controlWorkModeDP", code=data.get("code"))
+            await self._reauth(trigger="controlWorkModeDP", code=data.get("code"), rejected_token=used_token)
             headers = self._auth_headers()
             if hid is not None:
                 headers["hid"] = str(hid)

--- a/custom_components/homgar/api/client.py
+++ b/custom_components/homgar/api/client.py
@@ -357,6 +357,12 @@ class HomGarClient:
                 raise HomGarApiError(f"getDeviceStatus HTTP {resp.status}")
             data = await resp.json()
         _LOGGER.debug("API response: get_device_status data=%s", data)
+        if data.get("code") in (1001, 1004):
+            await self._reauth()
+            async with self._get(url, headers=self._auth_headers(), params=params) as resp2:
+                if resp2.status != 200:
+                    raise HomGarApiError(f"getDeviceStatus HTTP {resp2.status}")
+                data = await resp2.json()
         if data.get("code") != 0:
             raise HomGarApiError(f"getDeviceStatus failed: {data}")
         return data.get("data", {})
@@ -414,6 +420,16 @@ class HomGarClient:
                 raise HomGarApiError(f"subscribeStatus HTTP {resp.status}")
             data = await resp.json()
         _LOGGER.debug("API response: subscribe_status data=%s", data)
+        # A rejected token (1001 NOT_TOKEN / 1004) here strands the periodic MQTT
+        # renewal in a retry storm, since ensure_auth only checks the local clock.
+        # Re-auth and retry once, as the read endpoints do.
+        if data.get("code") in (1001, 1004):
+            await self._reauth()
+            async with self._post(url, headers=self._auth_headers(), json=payload) as resp2:
+                if resp2.status != 200:
+                    raise HomGarApiError(f"subscribeStatus HTTP {resp2.status}")
+                data = await resp2.json()
+            _LOGGER.debug("API response (after reauth): subscribe_status data=%s", data)
         if data.get("code") != 0:
             raise HomGarApiError(f"subscribeStatus failed: {data}")
         return data.get("data", {})
@@ -433,9 +449,15 @@ class HomGarClient:
             if resp.status != 200:
                 raise HomGarApiError(f"Failed to set device state: {resp.status}")
             data = await resp.json()
-            if data.get("code") != 0:
-                raise HomGarApiError(f"Set device state API error: {data.get('msg')}")
-            return True
+        if data.get("code") in (1001, 1004):
+            await self._reauth()
+            async with self._post(url, headers=self._auth_headers(), json=payload) as resp2:
+                if resp2.status != 200:
+                    raise HomGarApiError(f"Failed to set device state: {resp2.status}")
+                data = await resp2.json()
+        if data.get("code") != 0:
+            raise HomGarApiError(f"Set device state API error: {data.get('msg')}")
+        return True
 
     async def get_product_models(self, version: int = 0) -> list[dict]:
         """Get full product model list from API.
@@ -453,7 +475,16 @@ class HomGarClient:
             data = await resp.json()
         
         _LOGGER.warning("API response: get_product_models received, code=%s", data.get('code'))
-        
+
+        if isinstance(data, dict) and data.get("code") in (1001, 1004):
+            await self._reauth()
+            async with self._get(url, headers=self._auth_headers(), params=params) as resp2:
+                if resp2.status != 200:
+                    raise HomGarApiError(f"get_product_models HTTP {resp2.status}")
+                data = await resp2.json()
+            _LOGGER.warning("API response (after reauth): get_product_models code=%s",
+                            data.get('code') if isinstance(data, dict) else None)
+
         # Log full response to file for inspection
         try:
             with open('/tmp/product_models.json', 'w') as f:
@@ -563,6 +594,19 @@ class HomGarClient:
 
         _LOGGER.debug("API response: control_work_mode data=%s", data)
 
+        # Token rejected server-side (expired/rotated). Re-auth and retry once, as
+        # the read endpoints do — otherwise a stale token turns a valve command
+        # into a hard "code=1004 token error" even though a fresh login would
+        # succeed. Surfaced once the #75/#76 User-Agent fix let control calls
+        # actually reach the cloud.
+        if data.get("code") in (1001, 1004):
+            await self._reauth()
+            async with self._post(url, json=payload, headers=self._auth_headers()) as resp2:
+                if resp2.status != 200:
+                    raise HomGarApiError(f"controlWorkMode HTTP {resp2.status}")
+                data = await resp2.json()
+            _LOGGER.debug("API response (after reauth): control_work_mode data=%s", data)
+
         code = data.get("code")
         if code == 4:
             _LOGGER.warning(
@@ -613,6 +657,22 @@ class HomGarClient:
             data = await resp.json()
 
         _LOGGER.debug("API response: control_work_mode_dp data=%s", data)
+
+        # Token rejected server-side (expired/rotated). Re-auth and retry once, as
+        # the read endpoints do — otherwise a stale token turns a valve command
+        # into a hard "code=1004 token error" even though a fresh login would
+        # succeed. Surfaced once the #75/#76 User-Agent fix let control calls
+        # actually reach the cloud.
+        if data.get("code") in (1001, 1004):
+            await self._reauth()
+            headers = self._auth_headers()
+            if hid is not None:
+                headers["hid"] = str(hid)
+            async with self._post(url, json=payload, headers=headers) as resp2:
+                if resp2.status != 200:
+                    raise HomGarApiError(f"controlWorkModeDP HTTP {resp2.status}")
+                data = await resp2.json()
+            _LOGGER.debug("API response (after reauth): control_work_mode_dp data=%s", data)
 
         code = data.get("code")
         if code == 4:

--- a/custom_components/homgar/api/client.py
+++ b/custom_components/homgar/api/client.py
@@ -52,6 +52,12 @@ class HomGarClient:
         self._token_expires_at: datetime | None = None
         self._mqtt_credentials: dict = {}
 
+        # Session-scoped token re-auth telemetry (exposed via diagnostic sensors).
+        self._reauth_count = 0
+        self._last_reauth_at: datetime | None = None
+        self._last_reauth_trigger: str | None = None
+        self._last_reauth_code: int | None = None
+
         # region host: you had region3; we can later make this configurable
         self._base_url = "https://region3.homgarus.com"
         
@@ -257,13 +263,40 @@ class HomGarClient:
             if not await self.refresh_token():
                 raise HomGarApiError("Authentication failed")
 
-    async def _reauth(self) -> None:
+    async def _reauth(self, trigger: str | None = None, code: int | None = None) -> None:
         """Force a fresh login, invalidating the current token."""
-        _LOGGER.info("HomGar: token rejected by server, forcing fresh login")
+        self._reauth_count += 1
+        self._last_reauth_at = datetime.now(timezone.utc)
+        self._last_reauth_trigger = trigger
+        self._last_reauth_code = code
+        _LOGGER.info(
+            "HomGar: token rejected by server (trigger=%s code=%s), forcing fresh login (reauth #%d)",
+            trigger, code, self._reauth_count,
+        )
         self._token = None
         self._token_expires_at = None
         if not await self.login():
             raise HomGarApiError("Re-authentication failed")
+
+    @property
+    def reauth_count(self) -> int:
+        return self._reauth_count
+
+    @property
+    def last_reauth_at(self) -> datetime | None:
+        return self._last_reauth_at
+
+    @property
+    def last_reauth_trigger(self) -> str | None:
+        return self._last_reauth_trigger
+
+    @property
+    def last_reauth_code(self) -> int | None:
+        return self._last_reauth_code
+
+    @property
+    def token_expires_at(self) -> datetime | None:
+        return self._token_expires_at
 
     # --- API calls ---
 
@@ -279,7 +312,7 @@ class HomGarClient:
             data = await resp.json()
             _LOGGER.debug("API response: list_homes data=%s", data)
         if data.get("code") in (1001, 1004):
-            await self._reauth()
+            await self._reauth(trigger="list_homes", code=data.get("code"))
             async with self._get(url, headers=self._auth_headers()) as resp2:
                 data = await resp2.json()
         if data.get("code") != 0:
@@ -298,7 +331,7 @@ class HomGarClient:
             data = await resp.json()
         _LOGGER.debug("API response: get_devices_by_hid data=%s", data)
         if data.get("code") in (1001, 1004):
-            await self._reauth()
+            await self._reauth(trigger="getDeviceByHid", code=data.get("code"))
             async with self._get(url, headers=self._auth_headers(), params=params) as resp2:
                 data = await resp2.json()
         if data.get("code") != 0:
@@ -327,7 +360,7 @@ class HomGarClient:
             data = await resp.json()
         _LOGGER.debug("API response: get_multiple_device_status data=%s", data)
         if data.get("code") in (1001, 1004):
-            await self._reauth()
+            await self._reauth(trigger="multipleDeviceStatus", code=data.get("code"))
             async with self._post(url, headers=self._auth_headers(), json=payload) as resp2:
                 data = await resp2.json()
         if data.get("code") != 0:
@@ -358,7 +391,7 @@ class HomGarClient:
             data = await resp.json()
         _LOGGER.debug("API response: get_device_status data=%s", data)
         if data.get("code") in (1001, 1004):
-            await self._reauth()
+            await self._reauth(trigger="getDeviceStatus", code=data.get("code"))
             async with self._get(url, headers=self._auth_headers(), params=params) as resp2:
                 if resp2.status != 200:
                     raise HomGarApiError(f"getDeviceStatus HTTP {resp2.status}")
@@ -424,7 +457,7 @@ class HomGarClient:
         # renewal in a retry storm, since ensure_auth only checks the local clock.
         # Re-auth and retry once, as the read endpoints do.
         if data.get("code") in (1001, 1004):
-            await self._reauth()
+            await self._reauth(trigger="subscribeStatus", code=data.get("code"))
             async with self._post(url, headers=self._auth_headers(), json=payload) as resp2:
                 if resp2.status != 200:
                     raise HomGarApiError(f"subscribeStatus HTTP {resp2.status}")
@@ -450,7 +483,7 @@ class HomGarClient:
                 raise HomGarApiError(f"Failed to set device state: {resp.status}")
             data = await resp.json()
         if data.get("code") in (1001, 1004):
-            await self._reauth()
+            await self._reauth(trigger="setDeviceStatus", code=data.get("code"))
             async with self._post(url, headers=self._auth_headers(), json=payload) as resp2:
                 if resp2.status != 200:
                     raise HomGarApiError(f"Failed to set device state: {resp2.status}")
@@ -477,7 +510,7 @@ class HomGarClient:
         _LOGGER.warning("API response: get_product_models received, code=%s", data.get('code'))
 
         if isinstance(data, dict) and data.get("code") in (1001, 1004):
-            await self._reauth()
+            await self._reauth(trigger="productModel", code=data.get("code"))
             async with self._get(url, headers=self._auth_headers(), params=params) as resp2:
                 if resp2.status != 200:
                     raise HomGarApiError(f"get_product_models HTTP {resp2.status}")
@@ -600,7 +633,7 @@ class HomGarClient:
         # succeed. Surfaced once the #75/#76 User-Agent fix let control calls
         # actually reach the cloud.
         if data.get("code") in (1001, 1004):
-            await self._reauth()
+            await self._reauth(trigger="controlWorkMode", code=data.get("code"))
             async with self._post(url, json=payload, headers=self._auth_headers()) as resp2:
                 if resp2.status != 200:
                     raise HomGarApiError(f"controlWorkMode HTTP {resp2.status}")
@@ -664,7 +697,7 @@ class HomGarClient:
         # succeed. Surfaced once the #75/#76 User-Agent fix let control calls
         # actually reach the cloud.
         if data.get("code") in (1001, 1004):
-            await self._reauth()
+            await self._reauth(trigger="controlWorkModeDP", code=data.get("code"))
             headers = self._auth_headers()
             if hid is not None:
                 headers["hid"] = str(hid)

--- a/custom_components/homgar/diagnostic_token_sensors.py
+++ b/custom_components/homgar/diagnostic_token_sensors.py
@@ -1,0 +1,115 @@
+"""Token re-auth diagnostic sensors (v3.0.41).
+
+Three local-only DIAGNOSTIC sensors on the Hub device that expose the client's
+session token re-auth telemetry, so a token being rejected repeatedly (e.g. a
+concurrent-session war) is visible from the HA history graph. No network, no
+PII. See docs/superpowers/specs/2026-07-24-token-reauth-diagnostic-sensors-design.md.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
+from homeassistant.const import EntityCategory
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import HomGarCoordinator
+
+
+class _HomGarTokenSensorBase(CoordinatorEntity, SensorEntity):
+    """Base for the account-level token diagnostic sensors (one set per entry)."""
+
+    _attr_should_poll = False
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = True
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: HomGarCoordinator, hub_info: dict, entry_id: str) -> None:
+        super().__init__(coordinator)
+        self._hub_info = hub_info
+        self._entry_id = entry_id
+
+    @property
+    def _client(self):
+        return self.coordinator._client
+
+    @property
+    def available(self) -> bool:
+        return self.coordinator._client is not None
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        mid = self._hub_info["mid"]
+        return DeviceInfo(identifiers={(DOMAIN, f"rainpoint_hub_{mid}")})
+
+
+class HomGarTokenReauthCountSensor(_HomGarTokenSensorBase):
+    """Number of token re-authentications since HA (re)started."""
+
+    _attr_icon = "mdi:counter"
+    _attr_name = "Token re-auth count"
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+
+    def __init__(self, coordinator, hub_info, entry_id):
+        super().__init__(coordinator, hub_info, entry_id)
+        self._attr_unique_id = f"{entry_id}_token_reauth_count"
+
+    @property
+    def native_value(self) -> int:
+        return self._client.reauth_count
+
+
+class HomGarLastTokenReauthSensor(_HomGarTokenSensorBase):
+    """Timestamp of the most recent token re-authentication."""
+
+    _attr_icon = "mdi:key-alert"
+    _attr_name = "Last token re-auth"
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+
+    def __init__(self, coordinator, hub_info, entry_id):
+        super().__init__(coordinator, hub_info, entry_id)
+        self._attr_unique_id = f"{entry_id}_last_token_reauth"
+
+    @property
+    def native_value(self) -> datetime | None:
+        return self._client.last_reauth_at
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        return {
+            "trigger_endpoint": self._client.last_reauth_trigger,
+            "last_error_code": self._client.last_reauth_code,
+        }
+
+
+class HomGarTokenExpiresAtSensor(_HomGarTokenSensorBase):
+    """When the current token expires (far future => not natural expiry)."""
+
+    _attr_icon = "mdi:clock-end"
+    _attr_name = "Token expires at"
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+
+    def __init__(self, coordinator, hub_info, entry_id):
+        super().__init__(coordinator, hub_info, entry_id)
+        self._attr_unique_id = f"{entry_id}_token_expires_at"
+
+    @property
+    def native_value(self) -> datetime | None:
+        return self._client.token_expires_at
+
+
+def build_token_diagnostic_sensors(
+    coordinator: HomGarCoordinator, hub_info: dict, entry_id: str
+) -> list[_HomGarTokenSensorBase]:
+    """Build the one-per-entry token diagnostic sensor set."""
+    return [
+        HomGarTokenReauthCountSensor(coordinator, hub_info, entry_id),
+        HomGarLastTokenReauthSensor(coordinator, hub_info, entry_id),
+        HomGarTokenExpiresAtSensor(coordinator, hub_info, entry_id),
+    ]

--- a/custom_components/homgar/manifest.json
+++ b/custom_components/homgar/manifest.json
@@ -13,5 +13,5 @@
         "custom_components.homgar"
     ],
     "requirements": ["paho-mqtt>=1.6.0"],
-    "version": "3.0.40"
+    "version": "3.0.41"
 }

--- a/custom_components/homgar/sensor.py
+++ b/custom_components/homgar/sensor.py
@@ -34,6 +34,7 @@ from .diagnostic_sensors import (
     HomGarMqttRawPayloadSensor,
     HomGarMqttFriendlySensor,
 )
+from .diagnostic_token_sensors import build_token_diagnostic_sensors
 from .hub_entities import (
     HomGarHubDeviceIDSensor,
     HomGarHubFirmwareSensor,
@@ -108,6 +109,14 @@ async def async_setup_entry(
         entities.append(HomGarHubMqttFriendlySensor(coordinator, hub_info))
         entities.append(HomGarHubChannelSelect(coordinator, hub_info))
         entities.append(HomGarHubBroadcastSwitch(coordinator, hub_info))
+
+    # Account-level token diagnostic sensors: one set per config entry, attached
+    # to the first hub's device. Guarded so entries with no hub add nothing.
+    if hubs_dict:
+        first_hub_info = next(iter(hubs_dict.values()))
+        entities.extend(
+            build_token_diagnostic_sensors(coordinator, first_hub_info, entry.entry_id)
+        )
 
     # Create sensor entities for sub-devices
     for key, info in sensors_cfg.items():

--- a/docs/superpowers/plans/2026-07-24-token-reauth-diagnostic-sensors.md
+++ b/docs/superpowers/plans/2026-07-24-token-reauth-diagnostic-sensors.md
@@ -1,0 +1,708 @@
+# Token re-auth diagnostic sensors — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose token re-authentication activity as three enabled, local-only HA diagnostic sensors on the Hub device so the "token times out every minute" question is answerable from the history graph.
+
+**Architecture:** Instrument the single `HomGarClient._reauth()` choke point with session-scoped counters/timestamps and read-only accessors. Add a focused `diagnostic_token_sensors.py` with three `CoordinatorEntity` sensors that read that client state and attach to the Hub device, wired into `sensor.py:async_setup_entry` once per config entry.
+
+**Tech Stack:** Python 3 (HA custom integration), aiohttp client, Home Assistant `SensorEntity`/`CoordinatorEntity`. Tests are standalone `tests/run_*.py` scripts executed in the `ha-test` Docker container (Python 3.14).
+
+## Global Constraints
+
+- Sensors are **local-only**: no network calls, no PII, no opt-in. (Worker telemetry is a separate future change.)
+- Sensors are **DIAGNOSTIC** category and **enabled by default**.
+- Re-auth counter is **session-scoped** (resets on HA restart).
+- Attach to the **Hub** device: `identifiers={(DOMAIN, f"rainpoint_hub_{mid}")}`.
+- Bundle into the existing `fix/control-token-reauth` branch → **v3.0.41** (manifest already `3.0.41`).
+- No Claude attribution in commits/PRs.
+- `_reauth()` signature stays backward-compatible: new args are optional keyword args with defaults.
+- Tests run in the container: `docker cp` the repo tree to `/tmp/repo` (clean-remove first, docker cp nests on an existing dir) or rely on the pre-commit gate's `/config` deploy; import integration modules via `sys.path.insert(0, '/config')`.
+
+---
+
+### Task 1: Instrument `_reauth()` with telemetry state + accessors
+
+**Files:**
+- Modify: `custom_components/homgar/api/client.py` (add state in `__init__`, params + body in `_reauth`, accessor properties, update 9 call sites)
+- Test: `tests/run_token_diag_tests.py` (create)
+
+**Interfaces:**
+- Produces (on `HomGarClient`):
+  - `_reauth(self, trigger: str | None = None, code: int | None = None) -> None`
+  - `reauth_count: int` (property) — session total, starts at 0
+  - `last_reauth_at: datetime | None` (property) — UTC aware
+  - `last_reauth_trigger: str | None` (property)
+  - `last_reauth_code: int | None` (property)
+  - `token_expires_at: datetime | None` (property) — exposes existing `_token_expires_at`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/run_token_diag_tests.py`:
+
+```python
+"""Regression tests: HomGarClient exposes token re-auth telemetry.
+
+The three diagnostic sensors (added in v3.0.41) read this state. We pin that
+_reauth() increments a session counter and records when/what triggered it, and
+that the read-only accessors reflect it. See the token-reauth diagnostic spec.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+import types
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+
+def _find_repo_root() -> Path:
+    candidates = [Path(__file__).resolve().parent, Path.cwd(), Path("/config")]
+    for start in candidates:
+        current = start
+        while True:
+            if (current / "custom_components" / "homgar" / "api" / "client.py").exists():
+                return current
+            if current.parent == current:
+                break
+            current = current.parent
+    raise RuntimeError("Could not locate repository root containing custom_components/homgar")
+
+
+ROOT = _find_repo_root()
+
+
+def _load_module(module_name: str, relative_path: str):
+    path = ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load module from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _ClientTimeout:
+    def __init__(self, total=None, connect=None, sock_connect=None, sock_read=None):
+        self.total = total
+
+
+_aiohttp_stub = types.ModuleType("aiohttp")
+_aiohttp_stub.ClientTimeout = _ClientTimeout
+_aiohttp_stub.ClientSession = type("ClientSession", (), {})
+_aiohttp_stub.ClientError = type("ClientError", (Exception,), {})
+sys.modules["aiohttp"] = _aiohttp_stub
+
+sys.modules.setdefault("custom_components", types.ModuleType("custom_components"))
+sys.modules.setdefault("custom_components.homgar", types.ModuleType("custom_components.homgar"))
+sys.modules.setdefault("custom_components.homgar.api", types.ModuleType("custom_components.homgar.api"))
+_load_module("custom_components.homgar.const", "custom_components/homgar/const.py")
+client_mod = _load_module("custom_components.homgar.api.client", "custom_components/homgar/api/client.py")
+
+
+PASS = 0
+FAIL = 0
+
+
+def check(name: str, condition: bool, detail: str = "") -> None:
+    global PASS, FAIL
+    if condition:
+        print(f"  ✅ {name}")
+        PASS += 1
+    else:
+        print(f"  ❌ {name}{': ' + detail if detail else ''}")
+        FAIL += 1
+
+
+class _FakeResp:
+    def __init__(self, payload):
+        self._payload = payload
+        self.status = 200
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def json(self):
+        return self._payload
+
+    async def text(self):
+        return ""
+
+
+_LOGIN_PAYLOAD = {
+    "code": 0, "ts": 1700000000000,
+    "data": {"token": "fresh", "refreshToken": "r", "tokenExpired": 3600, "user": {}},
+}
+
+
+class _SequencedSession:
+    def __init__(self, queues):
+        self._queues = {u: list(p) for u, p in queues.items()}
+
+    def _next(self, url):
+        if url.endswith("/auth/basic/app/login"):
+            return _FakeResp(_LOGIN_PAYLOAD)
+        for key, queue in self._queues.items():
+            if url.endswith(key) and queue:
+                return _FakeResp(queue.pop(0))
+        raise AssertionError(f"No queued response for {url}")
+
+    def post(self, url, **kwargs):
+        return self._next(url)
+
+    def get(self, url, **kwargs):
+        return self._next(url)
+
+
+def _make_client(queues):
+    session = _SequencedSession(queues)
+    client = client_mod.HomGarClient("31", "a@b.com", "pw", session, "homgar")
+    client._token = "stale"
+    client._refresh_token = "stale-r"
+    client._token_expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
+    return client
+
+
+def _test_initial_state():
+    client = _make_client({})
+    check("reauth_count starts at 0", client.reauth_count == 0, f"got {client.reauth_count}")
+    check("last_reauth_at starts None", client.last_reauth_at is None)
+    check("last_reauth_trigger starts None", client.last_reauth_trigger is None)
+    check("last_reauth_code starts None", client.last_reauth_code is None)
+    check("token_expires_at accessor works", client.token_expires_at is not None)
+
+
+async def _test_reauth_records_telemetry():
+    # subscribe_status hits 1001 then recovers -> one reauth recorded.
+    ok = {"code": 0, "data": {"deviceName": "x"}}
+    client = _make_client({"/app/device/subscribeStatus": [{"code": 1001, "msg": "NOT_TOKEN"}, ok]})
+    await client.subscribe_status(hid=1, hubs=[{"deviceName": "d", "mid": 1, "productKey": "p", "hid": 1}])
+    check("reauth_count == 1 after one rejection", client.reauth_count == 1, f"got {client.reauth_count}")
+    check("last_reauth_at is set", client.last_reauth_at is not None)
+    check("trigger recorded as subscribeStatus", client.last_reauth_trigger == "subscribeStatus",
+          f"got {client.last_reauth_trigger!r}")
+    check("code recorded as 1001", client.last_reauth_code == 1001, f"got {client.last_reauth_code}")
+
+
+async def _test_reauth_count_is_monotonic():
+    client = _make_client({})
+    await client._reauth(trigger="controlWorkMode", code=1004)
+    await client._reauth(trigger="getDeviceStatus", code=1004)
+    check("reauth_count increments to 2", client.reauth_count == 2, f"got {client.reauth_count}")
+    check("latest trigger wins", client.last_reauth_trigger == "getDeviceStatus",
+          f"got {client.last_reauth_trigger!r}")
+
+
+def main() -> int:
+    print("Token diagnostic telemetry tests")
+    _test_initial_state()
+    asyncio.run(_test_reauth_records_telemetry())
+    asyncio.run(_test_reauth_count_is_monotonic())
+    print(f"\n{PASS} passed, {FAIL} failed")
+    return 1 if FAIL else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+docker exec ha-test rm -rf /tmp/repo && docker exec ha-test mkdir -p /tmp/repo
+docker cp custom_components ha-test:/tmp/repo/custom_components >/dev/null
+docker cp tests ha-test:/tmp/repo/tests >/dev/null
+docker exec ha-test python3 /tmp/repo/tests/run_token_diag_tests.py
+```
+Expected: FAIL — `AttributeError: 'HomGarClient' object has no attribute 'reauth_count'` (accessor not defined yet).
+
+- [ ] **Step 3: Add telemetry state to `__init__`**
+
+In `custom_components/homgar/api/client.py`, in `HomGarClient.__init__`, after the existing token-state lines (`self._token: str | None = None` … `self._mqtt_credentials: dict = {}`), add:
+
+```python
+        # Session-scoped token re-auth telemetry (exposed via diagnostic sensors).
+        self._reauth_count = 0
+        self._last_reauth_at: datetime | None = None
+        self._last_reauth_trigger: str | None = None
+        self._last_reauth_code: int | None = None
+```
+
+- [ ] **Step 4: Update `_reauth()` to accept and record telemetry**
+
+Replace the `_reauth` method body:
+
+```python
+    async def _reauth(self, trigger: str | None = None, code: int | None = None) -> None:
+        """Force a fresh login, invalidating the current token."""
+        self._reauth_count += 1
+        self._last_reauth_at = datetime.now(timezone.utc)
+        self._last_reauth_trigger = trigger
+        self._last_reauth_code = code
+        _LOGGER.info(
+            "HomGar: token rejected by server (trigger=%s code=%s), forcing fresh login (reauth #%d)",
+            trigger, code, self._reauth_count,
+        )
+        self._token = None
+        self._token_expires_at = None
+        if not await self.login():
+            raise HomGarApiError("Re-authentication failed")
+```
+
+- [ ] **Step 5: Add read-only accessor properties**
+
+Immediately after `_reauth`, add:
+
+```python
+    @property
+    def reauth_count(self) -> int:
+        return self._reauth_count
+
+    @property
+    def last_reauth_at(self) -> datetime | None:
+        return self._last_reauth_at
+
+    @property
+    def last_reauth_trigger(self) -> str | None:
+        return self._last_reauth_trigger
+
+    @property
+    def last_reauth_code(self) -> int | None:
+        return self._last_reauth_code
+
+    @property
+    def token_expires_at(self) -> datetime | None:
+        return self._token_expires_at
+```
+
+- [ ] **Step 6: Pass trigger/code at all 9 call sites**
+
+For each endpoint, change its `await self._reauth()` to pass the endpoint label and the rejecting code. The preceding line is always `if data.get("code") in (1001, 1004):`. Make these exact replacements:
+
+| Method | New call |
+|---|---|
+| `list_homes` | `await self._reauth(trigger="list_homes", code=data.get("code"))` |
+| `get_devices_by_hid` | `await self._reauth(trigger="getDeviceByHid", code=data.get("code"))` |
+| `get_multiple_device_status` | `await self._reauth(trigger="multipleDeviceStatus", code=data.get("code"))` |
+| `get_device_status` | `await self._reauth(trigger="getDeviceStatus", code=data.get("code"))` |
+| `subscribe_status` | `await self._reauth(trigger="subscribeStatus", code=data.get("code"))` |
+| `set_device_state` | `await self._reauth(trigger="setDeviceStatus", code=data.get("code"))` |
+| `get_product_models` | `await self._reauth(trigger="productModel", code=data.get("code"))` |
+| `control_work_mode` | `await self._reauth(trigger="controlWorkMode", code=data.get("code"))` |
+| `control_work_mode_dp` | `await self._reauth(trigger="controlWorkModeDP", code=data.get("code"))` |
+
+(9 occurrences of `await self._reauth()` → the labeled form. Verify none remain: `grep -n "self._reauth()" custom_components/homgar/api/client.py` returns nothing.)
+
+- [ ] **Step 7: Run diag test to verify it passes**
+
+```bash
+docker exec ha-test rm -rf /tmp/repo/custom_components && docker cp custom_components ha-test:/tmp/repo/custom_components >/dev/null
+docker exec ha-test python3 /tmp/repo/tests/run_token_diag_tests.py
+```
+Expected: PASS — `12 passed, 0 failed`.
+
+- [ ] **Step 8: Run the existing token-reauth suite to confirm no regression**
+
+```bash
+docker cp tests ha-test:/tmp/repo/tests >/dev/null
+docker exec ha-test python3 /tmp/repo/tests/run_token_reauth_tests.py
+```
+Expected: PASS — `23 passed, 0 failed` (defaulted args keep old behaviour).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add custom_components/homgar/api/client.py tests/run_token_diag_tests.py
+git commit -m "feat(api): record session token re-auth telemetry on _reauth()"
+```
+
+---
+
+### Task 2: Add the three Hub diagnostic sensors
+
+**Files:**
+- Create: `custom_components/homgar/diagnostic_token_sensors.py`
+- Test: `tests/run_token_sensor_tests.py` (create — runs in-container, imports HA via `/config`)
+
+**Interfaces:**
+- Consumes (from Task 1): `client.reauth_count`, `client.last_reauth_at`, `client.last_reauth_trigger`, `client.last_reauth_code`, `client.token_expires_at`; `coordinator._client`.
+- Produces:
+  - `HomGarTokenReauthCountSensor(coordinator, hub_info, entry_id)`
+  - `HomGarLastTokenReauthSensor(coordinator, hub_info, entry_id)`
+  - `HomGarTokenExpiresAtSensor(coordinator, hub_info, entry_id)`
+  - `build_token_diagnostic_sensors(coordinator, hub_info, entry_id) -> list` (factory used by `sensor.py`)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/run_token_sensor_tests.py` (runs inside the container where `homeassistant` is importable):
+
+```python
+"""Token diagnostic sensor tests. Runs in the ha-test container against the
+deployed integration at /config (imports Home Assistant)."""
+import sys
+import types
+from datetime import datetime, timedelta, timezone
+
+sys.path.insert(0, "/config")
+
+from custom_components.homgar.diagnostic_token_sensors import (  # noqa: E402
+    HomGarTokenReauthCountSensor,
+    HomGarLastTokenReauthSensor,
+    HomGarTokenExpiresAtSensor,
+    build_token_diagnostic_sensors,
+)
+from homeassistant.components.sensor import SensorStateClass, SensorDeviceClass  # noqa: E402
+from homeassistant.const import EntityCategory  # noqa: E402
+
+PASS = 0
+FAIL = 0
+
+
+def check(name, cond, detail=""):
+    global PASS, FAIL
+    if cond:
+        print(f"  ✅ {name}"); PASS += 1
+    else:
+        print(f"  ❌ {name}{': ' + detail if detail else ''}"); FAIL += 1
+
+
+now = datetime.now(timezone.utc)
+expires = now + timedelta(days=38)
+client = types.SimpleNamespace(
+    reauth_count=7,
+    last_reauth_at=now,
+    last_reauth_trigger="subscribeStatus",
+    last_reauth_code=1001,
+    token_expires_at=expires,
+)
+coordinator = types.SimpleNamespace(_client=client, data={"hubs": []}, last_update_success=True)
+hub_info = {"mid": 12345, "name": "Hub", "model": "HWG023WBRF-V2"}
+ENTRY = "entry_abc"
+
+count = HomGarTokenReauthCountSensor(coordinator, hub_info, ENTRY)
+last = HomGarLastTokenReauthSensor(coordinator, hub_info, ENTRY)
+exp = HomGarTokenExpiresAtSensor(coordinator, hub_info, ENTRY)
+
+check("count native_value reads reauth_count", count.native_value == 7, f"got {count.native_value}")
+check("count is total_increasing", count.state_class == SensorStateClass.TOTAL_INCREASING)
+check("count is DIAGNOSTIC", count.entity_category == EntityCategory.DIAGNOSTIC)
+check("count enabled by default", count.entity_registry_enabled_default is True)
+check("count unique_id is entry-scoped",
+      count.unique_id == f"{ENTRY}_token_reauth_count", f"got {count.unique_id}")
+check("count attaches to hub device",
+      (DOMAIN_ID := ("homgar", f"rainpoint_hub_12345")) in count.device_info["identifiers"])
+
+check("last native_value is the reauth timestamp", last.native_value == now)
+check("last is timestamp device_class", last.device_class == SensorDeviceClass.TIMESTAMP)
+check("last exposes trigger attr",
+      last.extra_state_attributes.get("trigger_endpoint") == "subscribeStatus")
+check("last exposes error code attr",
+      last.extra_state_attributes.get("last_error_code") == 1001)
+
+check("expires native_value is token_expires_at", exp.native_value == expires)
+check("expires is timestamp device_class", exp.device_class == SensorDeviceClass.TIMESTAMP)
+
+built = build_token_diagnostic_sensors(coordinator, hub_info, ENTRY)
+check("factory returns exactly 3 sensors", len(built) == 3, f"got {len(built)}")
+
+print(f"\n{PASS} passed, {FAIL} failed")
+sys.exit(1 if FAIL else 0)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+docker cp tests/run_token_sensor_tests.py ha-test:/tmp/run_token_sensor_tests.py >/dev/null
+docker exec ha-test python3 /tmp/run_token_sensor_tests.py
+```
+Expected: FAIL — `ModuleNotFoundError: No module named 'custom_components.homgar.diagnostic_token_sensors'`.
+
+- [ ] **Step 3: Create the sensor module**
+
+Create `custom_components/homgar/diagnostic_token_sensors.py`:
+
+```python
+"""Token re-auth diagnostic sensors (v3.0.41).
+
+Three local-only DIAGNOSTIC sensors on the Hub device that expose the client's
+session token re-auth telemetry, so a token being rejected repeatedly (e.g. a
+concurrent-session war) is visible from the HA history graph. No network, no
+PII. See docs/superpowers/specs/2026-07-24-token-reauth-diagnostic-sensors-design.md.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
+from homeassistant.const import EntityCategory
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import HomGarCoordinator
+
+
+class _HomGarTokenSensorBase(CoordinatorEntity, SensorEntity):
+    """Base for the account-level token diagnostic sensors (one set per entry)."""
+
+    _attr_should_poll = False
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = True
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: HomGarCoordinator, hub_info: dict, entry_id: str) -> None:
+        super().__init__(coordinator)
+        self._hub_info = hub_info
+        self._entry_id = entry_id
+
+    @property
+    def _client(self):
+        return self.coordinator._client
+
+    @property
+    def available(self) -> bool:
+        return self.coordinator._client is not None
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        mid = self._hub_info["mid"]
+        return DeviceInfo(identifiers={(DOMAIN, f"rainpoint_hub_{mid}")})
+
+
+class HomGarTokenReauthCountSensor(_HomGarTokenSensorBase):
+    """Number of token re-authentications since HA (re)started."""
+
+    _attr_icon = "mdi:counter"
+    _attr_name = "Token re-auth count"
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+
+    def __init__(self, coordinator, hub_info, entry_id):
+        super().__init__(coordinator, hub_info, entry_id)
+        self._attr_unique_id = f"{entry_id}_token_reauth_count"
+
+    @property
+    def native_value(self) -> int:
+        return self._client.reauth_count
+
+
+class HomGarLastTokenReauthSensor(_HomGarTokenSensorBase):
+    """Timestamp of the most recent token re-authentication."""
+
+    _attr_icon = "mdi:key-alert"
+    _attr_name = "Last token re-auth"
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+
+    def __init__(self, coordinator, hub_info, entry_id):
+        super().__init__(coordinator, hub_info, entry_id)
+        self._attr_unique_id = f"{entry_id}_last_token_reauth"
+
+    @property
+    def native_value(self) -> datetime | None:
+        return self._client.last_reauth_at
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        return {
+            "trigger_endpoint": self._client.last_reauth_trigger,
+            "last_error_code": self._client.last_reauth_code,
+        }
+
+
+class HomGarTokenExpiresAtSensor(_HomGarTokenSensorBase):
+    """When the current token expires (far future => not natural expiry)."""
+
+    _attr_icon = "mdi:clock-end"
+    _attr_name = "Token expires at"
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+
+    def __init__(self, coordinator, hub_info, entry_id):
+        super().__init__(coordinator, hub_info, entry_id)
+        self._attr_unique_id = f"{entry_id}_token_expires_at"
+
+    @property
+    def native_value(self) -> datetime | None:
+        return self._client.token_expires_at
+
+
+def build_token_diagnostic_sensors(
+    coordinator: HomGarCoordinator, hub_info: dict, entry_id: str
+) -> list[_HomGarTokenSensorBase]:
+    """Build the one-per-entry token diagnostic sensor set."""
+    return [
+        HomGarTokenReauthCountSensor(coordinator, hub_info, entry_id),
+        HomGarLastTokenReauthSensor(coordinator, hub_info, entry_id),
+        HomGarTokenExpiresAtSensor(coordinator, hub_info, entry_id),
+    ]
+```
+
+- [ ] **Step 4: Fix the test's DOMAIN reference and re-run**
+
+The test references `("homgar", ...)`; the real domain constant is `DOMAIN` from const. Add near the top of `tests/run_token_sensor_tests.py` (after the `sys.path.insert`):
+
+```python
+from custom_components.homgar.const import DOMAIN  # noqa: E402
+```
+
+and change the `count attaches to hub device` check to:
+
+```python
+check("count attaches to hub device",
+      (DOMAIN, f"rainpoint_hub_12345") in count.device_info["identifiers"])
+```
+
+Then redeploy the integration to `/config` and run:
+
+```bash
+docker cp custom_components/homgar ha-test:/config/custom_components/ >/dev/null
+docker cp tests/run_token_sensor_tests.py ha-test:/tmp/run_token_sensor_tests.py >/dev/null
+docker exec ha-test python3 /tmp/run_token_sensor_tests.py
+```
+Expected: PASS — `15 passed, 0 failed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add custom_components/homgar/diagnostic_token_sensors.py tests/run_token_sensor_tests.py
+git commit -m "feat(sensor): add token re-auth diagnostic sensors on the Hub device"
+```
+
+---
+
+### Task 3: Wire into setup, gate, changelog; deploy & verify
+
+**Files:**
+- Modify: `custom_components/homgar/sensor.py` (import + create one set per entry in `async_setup_entry`)
+- Modify: `scripts/pre-commit-docker-test.sh` (run the two new suites)
+- Modify: `CHANGELOG.md` (Diagnostics bullet + Lovelace card)
+
+**Interfaces:**
+- Consumes (from Task 2): `build_token_diagnostic_sensors(coordinator, hub_info, entry_id)`.
+
+- [ ] **Step 1: Import the factory in `sensor.py`**
+
+In `custom_components/homgar/sensor.py`, after the `from .diagnostic_sensors import (...)` block (ends line ~36), add:
+
+```python
+from .diagnostic_token_sensors import build_token_diagnostic_sensors
+```
+
+- [ ] **Step 2: Create the sensors once per entry (on the first hub)**
+
+In `async_setup_entry`, immediately after the `for hub_key, hub_info in hubs_dict.items():` loop that adds hub sensors (right before the `# Create sensor entities for sub-devices` comment, ~line 112), add:
+
+```python
+    # Account-level token diagnostic sensors: one set per config entry, attached
+    # to the first hub's device. Guarded so entries with no hub add nothing.
+    if hubs_dict:
+        first_hub_info = next(iter(hubs_dict.values()))
+        entities.extend(
+            build_token_diagnostic_sensors(coordinator, first_hub_info, entry.entry_id)
+        )
+```
+
+- [ ] **Step 3: Add both suites to the pre-commit gate**
+
+In `scripts/pre-commit-docker-test.sh`, after the existing "token re-auth regression tests" block (ends with `fi` after the `run_token_reauth_tests.py` block), insert:
+
+```bash
+# ── Test: token telemetry + sensor regressions ────────────────────────────
+echo "🧪 Running token telemetry tests..."
+docker cp tests/run_token_diag_tests.py ha-test:/tmp/tests/run_token_diag_tests.py > /dev/null
+if docker exec ha-test python3 /tmp/tests/run_token_diag_tests.py; then
+    echo "✅ Token telemetry tests passed"
+else
+    echo "❌ ERROR: Token telemetry tests failed"
+    exit 1
+fi
+
+echo "🧪 Running token diagnostic sensor tests..."
+docker cp tests/run_token_sensor_tests.py ha-test:/tmp/run_token_sensor_tests.py > /dev/null
+if docker exec ha-test python3 /tmp/run_token_sensor_tests.py; then
+    echo "✅ Token diagnostic sensor tests passed"
+else
+    echo "❌ ERROR: Token diagnostic sensor tests failed"
+    exit 1
+fi
+```
+
+- [ ] **Step 4: Run the full pre-commit gate**
+
+```bash
+bash scripts/pre-commit-docker-test.sh 2>&1 | tail -n 30
+```
+Expected: `🎉 All pre-commit tests passed! Commit allowed.` The gate deploys the tree to `/config` and restarts HA.
+
+- [ ] **Step 5: Verify the three entities exist on the Hub with sane values**
+
+```bash
+docker exec ha-test sh -c 'python3 - <<"PY"
+import json
+d = json.load(open("/config/.storage/core.entity_registry"))
+toks = [e for e in d["data"]["entities"]
+        if e["platform"] == "homgar" and "token" in e["entity_id"]]
+for e in toks:
+    print(e["entity_id"], "| disabled_by:", e.get("disabled_by"), "| unique:", e["unique_id"])
+print("count:", len(toks))
+PY'
+```
+Expected: three rows — `sensor.*_token_reauth_count`, `*_last_token_reauth`, `*_token_expires_at` — all `disabled_by: None`. Also confirm no tracebacks:
+```bash
+docker exec ha-test sh -c 'grep -c Traceback /config/home-assistant.log'
+```
+Expected: `0`.
+
+- [ ] **Step 6: Add the Diagnostics changelog bullet + Lovelace card**
+
+In `CHANGELOG.md`, under the existing `## [3.0.41] - 2026-07-24` section, add a new subsection after the `### 🧪 Tests` block for that version:
+
+```markdown
+### 🔎 Diagnostics
+- **Token re-auth visibility** — three local-only diagnostic sensors on the Hub device make token re-authentication measurable: `Token re-auth count` (a `total_increasing` value whose history-graph slope shows how often the cloud is rejecting the token), `Last token re-auth` (timestamp, with `trigger_endpoint` and `last_error_code` attributes), and `Token expires at` (a far-future value here means the token is long-lived and any churn is external session invalidation, not expiry). Enabled by default, no data leaves Home Assistant. Find them under Settings → Devices & Services → HomGar/RainPoint → Hub → Diagnostic. To watch the rhythm on one graph:
+
+    ```yaml
+    type: history-graph
+    hours_to_show: 6
+    entities:
+      - sensor.homgar_token_reauth_count
+      - sensor.homgar_last_token_reauth
+      - sensor.homgar_token_expires_at
+    ```
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add custom_components/homgar/sensor.py scripts/pre-commit-docker-test.sh CHANGELOG.md
+git commit -m "feat(sensor): wire token diagnostic sensors into setup + gate + changelog"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Instrument `_reauth()` choke point (spec §1) → Task 1. ✓
+- Session-scoped state + accessors (spec §1) → Task 1 Steps 3–5. ✓
+- 9 call sites pass trigger + code (spec §1) → Task 1 Step 6. ✓
+- Three DIAGNOSTIC sensors, enabled by default, correct classes (spec §2) → Task 2. ✓
+- Attach to Hub device `rainpoint_hub_{mid}` (spec §3) → Task 2 `device_info`. ✓
+- One set per config entry, first hub, guarded (spec §2/§3) → Task 3 Step 2. ✓
+- TDD in container + pre-commit gate (spec Testing) → Tasks 1–3, gate in Task 3 Step 3–4. ✓
+- Deploy to ha-test, entities render, no tracebacks (spec Testing) → Task 3 Step 5. ✓
+- Bundle into v3.0.41, Diagnostics changelog bullet, Lovelace card (spec Delivery/§5) → Task 3 Step 6. ✓
+- Local-only, no telemetry push (spec Scope) → no network code added. ✓
+
+**Placeholder scan:** none — all steps carry exact code/commands.
+
+**Type consistency:** `_reauth(trigger, code)`, `reauth_count`, `last_reauth_at`, `last_reauth_trigger`, `last_reauth_code`, `token_expires_at`, `build_token_diagnostic_sensors(coordinator, hub_info, entry_id)`, and the three sensor class names are used identically across Tasks 1–3. ✓
+
+**Note on test counts:** "12/15 passed" figures are the sum of `check()` calls in each suite; if you add/remove a check, update the expected line accordingly.

--- a/docs/superpowers/specs/2026-07-24-token-reauth-diagnostic-sensors-design.md
+++ b/docs/superpowers/specs/2026-07-24-token-reauth-diagnostic-sensors-design.md
@@ -1,0 +1,156 @@
+# Token re-auth diagnostic sensors — design
+
+- **Date:** 2026-07-24
+- **Branch:** `fix/control-token-reauth` (bundled into the v3.0.41 release)
+- **Status:** approved, ready for implementation plan
+
+## Problem
+
+After v3.0.40 (User-Agent 403 fix) let requests reach the HomGar cloud again, a
+power user (@shaundekok) reported valve control failing with
+`controlWorkMode failed: code=1004 msg=token error` and the MQTT renewal loop
+stuck on `subscribeStatus failed: {'code': 1001, 'msg': 'NOT_TOKEN'}`, plus an
+impression that "the token times out every minute."
+
+The re-auth/retry recovery already committed on this branch converts those hard
+failures into silent recovery. But the **"every minute"** claim is unexplained
+and not reproducible on the maintainer's own account, where the token is
+long-lived (server lifetime ~60 days; one login at boot; 120 s HTTP poll). A
+token rejected every ~60 s is therefore not natural expiry — it points to an
+*external session invalidating the token* (concurrent phone app, or a duplicate
+config entry sharing the deterministic `deviceId`).
+
+We cannot see Shaun's token behaviour directly. We need to **make re-auth
+measurable inside any user's Home Assistant** so the rhythm is visible from the
+HA history graph, with zero data leaving HA.
+
+## Scope
+
+**In scope (this change):** local, HA-native diagnostic sensors that expose
+token re-auth activity. Purely local — no network, no PII, no opt-in.
+
+**Out of scope (deliberate follow-up):** pushing the same telemetry to the
+`homeassistant-homgar-debug-worker` Cloudflare Worker. That layer needs an
+explicit opt-in and a new worker endpoint, and is only worth building once the
+sensors confirm they capture the right signal. Tracked separately.
+
+## Design
+
+### 1. Instrument the single re-auth choke point
+
+All re-authentications funnel through `HomGarClient._reauth()`
+(`custom_components/homgar/api/client.py`). Add session-scoped state to the
+client (resets on HA restart — acceptable, churn shows within a session):
+
+```python
+self._reauth_count = 0            # running total this runtime
+self._last_reauth_at = None       # datetime, UTC
+self._last_reauth_trigger = None  # endpoint name, e.g. "subscribeStatus"
+self._last_reauth_code = None     # 1001 or 1004
+```
+
+`_reauth()` gains two optional arguments and updates the state:
+
+```python
+async def _reauth(self, trigger: str | None = None, code: int | None = None) -> None:
+    self._reauth_count += 1
+    self._last_reauth_at = datetime.now(timezone.utc)
+    self._last_reauth_trigger = trigger
+    self._last_reauth_code = code
+    ...  # existing behaviour: clear token, login()
+```
+
+All existing `_reauth()` call sites (the 3 read endpoints, the 2 control
+endpoints, `subscribeStatus`, `getDeviceStatus`, `setDeviceStatus`,
+`productModel`) pass their endpoint name and the rejecting code — both already
+in scope at the call site (`data.get("code")`). Example:
+
+```python
+if data.get("code") in (1001, 1004):
+    await self._reauth(trigger="subscribeStatus", code=data.get("code"))
+```
+
+`_token_expires_at` already exists; no change needed for expiry.
+
+Read-only accessors keep the sensor decoupled from client internals, e.g.
+`reauth_count`, `last_reauth_at`, `last_reauth_trigger`, `last_reauth_code`,
+`token_expires_at` (property or simple getters).
+
+### 2. Three DIAGNOSTIC sensors, one set per config entry, enabled by default
+
+New file `custom_components/homgar/diagnostic_token_sensors.py` (keeps
+`sensor.py` focused), wired into `sensor.py:async_setup_entry` beside the
+existing `diagnostic_sensors` import. One set per config entry.
+
+| Entity (object_id) | device_class / state_class | Source | Notes |
+|---|---|---|---|
+| `sensor.homgar_token_reauth_count` | numeric, `state_class=total_increasing` | `reauth_count` | The staircase; slope = churn rate; feeds long-term Statistics |
+| `sensor.homgar_last_token_reauth` | `device_class=timestamp` | `last_reauth_at` | attrs: `trigger_endpoint`, `last_error_code` |
+| `sensor.homgar_token_expires_at` | `device_class=timestamp` | `token_expires_at` | far-future value ⇒ not natural expiry |
+
+- `entity_category = EntityCategory.DIAGNOSTIC`, `entity_registry_enabled_default = True`.
+- `CoordinatorEntity`; `native_value` reads live client state each coordinator
+  refresh (120 s). Re-auths triggered by a coordinator *read* surface
+  immediately (that refresh finishes and pushes new data); re-auths triggered by
+  the independent MQTT renewal surface on the next cycle — up to 120 s lag,
+  acceptable for a minute-scale rhythm observed over several minutes.
+- Stable `unique_id` per config entry, e.g. `f"{entry_id}_token_reauth_count"`.
+
+### 3. Attach point (device)
+
+Attach to the top-level **Hub** device — the per-home gateway
+(`identifiers={(DOMAIN, f"rainpoint_hub_{mid}")}`), the closest thing to an
+account-level device. Token state is account-wide, so the Hub is its natural
+home. HA renders `DIAGNOSTIC` entities in their own "Diagnostic" card on the Hub
+device page. If an entry has multiple hubs, attach to the primary/first hub
+(one set per entry, not per hub).
+
+### 4. Where it surfaces (for reviewers)
+
+- **Device page:** Settings → Devices & Services → HomGar/RainPoint → **Hub** →
+  Diagnostic card shows the three sensors.
+- **Entities tab:** search `token`.
+- **History:** open *Token re-auth count* → History graph = the staircase; also
+  in long-term Statistics. *Last token re-auth* attributes show the last
+  `trigger_endpoint` / `last_error_code`.
+
+### 5. Optional: paste-ready Lovelace card
+
+Include a `history-graph` card snippet (all three sensors) in the PR body /
+README so the maintainer and Shaun get the staircase in one view without
+clicking around. Documentation only; no code dependency.
+
+## Testing
+
+TDD in the `ha-test` container (Python 3.14), extending the existing
+`tests/run_token_reauth_tests.py` style or a new `run_token_diag_tests.py`:
+
+1. `_reauth(trigger, code)` increments `reauth_count`, stamps `last_reauth_at`,
+   and records `trigger`/`code`.
+2. Multiple re-auths accumulate (count is monotonic within a session).
+3. Sensor `native_value` maps correctly for each of the three sensors, including
+   the `timestamp` device_class values and the `trigger_endpoint` /
+   `last_error_code` attributes.
+4. Sensors are enabled-by-default and in the DIAGNOSTIC category.
+
+Wire the suite into `scripts/pre-commit-docker-test.sh`. Full gate must pass;
+deploy to `ha-test` and confirm the three entities appear on the Hub device with
+sane values and no tracebacks.
+
+## Delivery
+
+- Bundle into the existing `fix/control-token-reauth` branch → **v3.0.41**, so a
+  single install gives users both the recovery fix and the visibility.
+- CHANGELOG 3.0.41 gains a second bullet under a **Diagnostics** heading
+  describing the three sensors and how to read the staircase.
+- manifest already at `3.0.41`.
+
+## Risks / notes
+
+- Adds three enabled entities to every user's Hub device. Mitigated by the
+  DIAGNOSTIC category (tucked away, not on default dashboards) and their obvious
+  debug purpose.
+- Session-scoped counter resets on restart; `total_increasing` handles resets
+  gracefully in HA history/statistics.
+- Up-to-120 s surfacing lag for MQTT-renewal-triggered re-auths; documented,
+  acceptable for the diagnostic goal.

--- a/scripts/pre-commit-docker-test.sh
+++ b/scripts/pre-commit-docker-test.sh
@@ -290,6 +290,16 @@ else
     exit 1
 fi
 
+# ── Test: token re-auth / retry regressions ───────────────────────────────
+echo "🧪 Running token re-auth regression tests..."
+docker cp tests/run_token_reauth_tests.py ha-test:/tmp/tests/run_token_reauth_tests.py > /dev/null
+if docker exec ha-test python3 /tmp/tests/run_token_reauth_tests.py; then
+    echo "✅ Token re-auth regression tests passed"
+else
+    echo "❌ ERROR: Token re-auth regression tests failed"
+    exit 1
+fi
+
 # ── Test: decoder regression suite (scripts/test_decoders.py) ─────────────
 echo "🧪 Running decoder regression suite..."
 docker cp scripts/test_decoders.py ha-test:/tmp/test_decoders.py > /dev/null

--- a/scripts/pre-commit-docker-test.sh
+++ b/scripts/pre-commit-docker-test.sh
@@ -300,6 +300,25 @@ else
     exit 1
 fi
 
+# ── Test: token telemetry + sensor regressions ────────────────────────────
+echo "🧪 Running token telemetry tests..."
+docker cp tests/run_token_diag_tests.py ha-test:/tmp/tests/run_token_diag_tests.py > /dev/null
+if docker exec ha-test python3 /tmp/tests/run_token_diag_tests.py; then
+    echo "✅ Token telemetry tests passed"
+else
+    echo "❌ ERROR: Token telemetry tests failed"
+    exit 1
+fi
+
+echo "🧪 Running token diagnostic sensor tests..."
+docker cp tests/run_token_sensor_tests.py ha-test:/tmp/run_token_sensor_tests.py > /dev/null
+if docker exec ha-test python3 /tmp/run_token_sensor_tests.py; then
+    echo "✅ Token diagnostic sensor tests passed"
+else
+    echo "❌ ERROR: Token diagnostic sensor tests failed"
+    exit 1
+fi
+
 # ── Test: decoder regression suite (scripts/test_decoders.py) ─────────────
 echo "🧪 Running decoder regression suite..."
 docker cp scripts/test_decoders.py ha-test:/tmp/test_decoders.py > /dev/null

--- a/tests/run_token_diag_tests.py
+++ b/tests/run_token_diag_tests.py
@@ -1,0 +1,168 @@
+"""Regression tests: HomGarClient exposes token re-auth telemetry.
+
+The three diagnostic sensors (added in v3.0.41) read this state. We pin that
+_reauth() increments a session counter and records when/what triggered it, and
+that the read-only accessors reflect it. See the token-reauth diagnostic spec.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+import types
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+
+def _find_repo_root() -> Path:
+    candidates = [Path(__file__).resolve().parent, Path.cwd(), Path("/config")]
+    for start in candidates:
+        current = start
+        while True:
+            if (current / "custom_components" / "homgar" / "api" / "client.py").exists():
+                return current
+            if current.parent == current:
+                break
+            current = current.parent
+    raise RuntimeError("Could not locate repository root containing custom_components/homgar")
+
+
+ROOT = _find_repo_root()
+
+
+def _load_module(module_name: str, relative_path: str):
+    path = ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load module from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _ClientTimeout:
+    def __init__(self, total=None, connect=None, sock_connect=None, sock_read=None):
+        self.total = total
+
+
+_aiohttp_stub = types.ModuleType("aiohttp")
+_aiohttp_stub.ClientTimeout = _ClientTimeout
+_aiohttp_stub.ClientSession = type("ClientSession", (), {})
+_aiohttp_stub.ClientError = type("ClientError", (Exception,), {})
+sys.modules["aiohttp"] = _aiohttp_stub
+
+sys.modules.setdefault("custom_components", types.ModuleType("custom_components"))
+sys.modules.setdefault("custom_components.homgar", types.ModuleType("custom_components.homgar"))
+sys.modules.setdefault("custom_components.homgar.api", types.ModuleType("custom_components.homgar.api"))
+_load_module("custom_components.homgar.const", "custom_components/homgar/const.py")
+client_mod = _load_module("custom_components.homgar.api.client", "custom_components/homgar/api/client.py")
+
+
+PASS = 0
+FAIL = 0
+
+
+def check(name: str, condition: bool, detail: str = "") -> None:
+    global PASS, FAIL
+    if condition:
+        print(f"  ✅ {name}")
+        PASS += 1
+    else:
+        print(f"  ❌ {name}{': ' + detail if detail else ''}")
+        FAIL += 1
+
+
+class _FakeResp:
+    def __init__(self, payload):
+        self._payload = payload
+        self.status = 200
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def json(self):
+        return self._payload
+
+    async def text(self):
+        return ""
+
+
+_LOGIN_PAYLOAD = {
+    "code": 0, "ts": 1700000000000,
+    "data": {"token": "fresh", "refreshToken": "r", "tokenExpired": 3600, "user": {}},
+}
+
+
+class _SequencedSession:
+    def __init__(self, queues):
+        self._queues = {u: list(p) for u, p in queues.items()}
+
+    def _next(self, url):
+        if url.endswith("/auth/basic/app/login"):
+            return _FakeResp(_LOGIN_PAYLOAD)
+        for key, queue in self._queues.items():
+            if url.endswith(key) and queue:
+                return _FakeResp(queue.pop(0))
+        raise AssertionError(f"No queued response for {url}")
+
+    def post(self, url, **kwargs):
+        return self._next(url)
+
+    def get(self, url, **kwargs):
+        return self._next(url)
+
+
+def _make_client(queues):
+    session = _SequencedSession(queues)
+    client = client_mod.HomGarClient("31", "a@b.com", "pw", session, "homgar")
+    client._token = "stale"
+    client._refresh_token = "stale-r"
+    client._token_expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
+    return client
+
+
+def _test_initial_state():
+    client = _make_client({})
+    check("reauth_count starts at 0", client.reauth_count == 0, f"got {client.reauth_count}")
+    check("last_reauth_at starts None", client.last_reauth_at is None)
+    check("last_reauth_trigger starts None", client.last_reauth_trigger is None)
+    check("last_reauth_code starts None", client.last_reauth_code is None)
+    check("token_expires_at accessor works", client.token_expires_at is not None)
+
+
+async def _test_reauth_records_telemetry():
+    # subscribe_status hits 1001 then recovers -> one reauth recorded.
+    ok = {"code": 0, "data": {"deviceName": "x"}}
+    client = _make_client({"/app/device/subscribeStatus": [{"code": 1001, "msg": "NOT_TOKEN"}, ok]})
+    await client.subscribe_status(hid=1, hubs=[{"deviceName": "d", "mid": 1, "productKey": "p", "hid": 1}])
+    check("reauth_count == 1 after one rejection", client.reauth_count == 1, f"got {client.reauth_count}")
+    check("last_reauth_at is set", client.last_reauth_at is not None)
+    check("trigger recorded as subscribeStatus", client.last_reauth_trigger == "subscribeStatus",
+          f"got {client.last_reauth_trigger!r}")
+    check("code recorded as 1001", client.last_reauth_code == 1001, f"got {client.last_reauth_code}")
+
+
+async def _test_reauth_count_is_monotonic():
+    client = _make_client({})
+    await client._reauth(trigger="controlWorkMode", code=1004)
+    await client._reauth(trigger="getDeviceStatus", code=1004)
+    check("reauth_count increments to 2", client.reauth_count == 2, f"got {client.reauth_count}")
+    check("latest trigger wins", client.last_reauth_trigger == "getDeviceStatus",
+          f"got {client.last_reauth_trigger!r}")
+
+
+def main() -> int:
+    print("Token diagnostic telemetry tests")
+    _test_initial_state()
+    asyncio.run(_test_reauth_records_telemetry())
+    asyncio.run(_test_reauth_count_is_monotonic())
+    print(f"\n{PASS} passed, {FAIL} failed")
+    return 1 if FAIL else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/run_token_diag_tests.py
+++ b/tests/run_token_diag_tests.py
@@ -100,9 +100,11 @@ _LOGIN_PAYLOAD = {
 class _SequencedSession:
     def __init__(self, queues):
         self._queues = {u: list(p) for u, p in queues.items()}
+        self.login_posts = 0
 
     def _next(self, url):
         if url.endswith("/auth/basic/app/login"):
+            self.login_posts += 1
             return _FakeResp(_LOGIN_PAYLOAD)
         for key, queue in self._queues.items():
             if url.endswith(key) and queue:
@@ -155,11 +157,38 @@ async def _test_reauth_count_is_monotonic():
           f"got {client.last_reauth_trigger!r}")
 
 
+async def _test_concurrent_reauth_single_login():
+    # Two callers whose in-flight requests used the same (now-rejected) token both
+    # trigger a re-auth in the same window. The auth lock must collapse them into
+    # ONE login instead of a re-login storm.
+    client = _make_client({})
+    used = client._token  # both in-flight requests used this (now-rejected) token
+    await asyncio.gather(
+        client._reauth(trigger="multipleDeviceStatus", code=1001, rejected_token=used),
+        client._reauth(trigger="subscribeStatus", code=1001, rejected_token=used),
+    )
+    check("concurrent re-auth performs exactly one login",
+          client._session.login_posts == 1, f"got {client._session.login_posts}")
+    check("concurrent re-auth counted once (no double increment)",
+          client.reauth_count == 1, f"got {client.reauth_count}")
+
+
+async def _test_single_reauth_still_logs_in():
+    # A lone re-auth (no concurrent refresher) must still perform its login.
+    client = _make_client({})
+    await client._reauth(trigger="controlWorkMode", code=1004)
+    check("single re-auth performs one login", client._session.login_posts == 1,
+          f"got {client._session.login_posts}")
+    check("single re-auth counted once", client.reauth_count == 1, f"got {client.reauth_count}")
+
+
 def main() -> int:
     print("Token diagnostic telemetry tests")
     _test_initial_state()
     asyncio.run(_test_reauth_records_telemetry())
     asyncio.run(_test_reauth_count_is_monotonic())
+    asyncio.run(_test_concurrent_reauth_single_login())
+    asyncio.run(_test_single_reauth_still_logs_in())
     print(f"\n{PASS} passed, {FAIL} failed")
     return 1 if FAIL else 0
 

--- a/tests/run_token_reauth_tests.py
+++ b/tests/run_token_reauth_tests.py
@@ -1,0 +1,318 @@
+"""Regression tests: valve control endpoints re-auth and retry on a token error.
+
+The HomGar cloud returns ``code=1004 "token error"`` when it rejects a token
+(rotation, or a local expiry clock that outlives the server-side token). The
+read endpoints (``list_homes`` etc.) already recover from this by calling
+``_reauth()`` and retrying once. The control endpoints (``control_work_mode`` /
+``control_work_mode_dp``) historically did NOT — a stale token turned a valve
+command into a hard ``HomGarApiError`` (reported following the User-Agent 403
+fix in #75/#76/#77, which first let control calls reach the cloud at all).
+
+These tests pin the recovery behaviour: a 1004 on a control call triggers a
+single fresh login and a retry, and a clean 0 response never re-auths.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+import types
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+
+def _find_repo_root() -> Path:
+    candidates = [Path(__file__).resolve().parent, Path.cwd(), Path("/config")]
+    for start in candidates:
+        current = start
+        while True:
+            if (current / "custom_components" / "homgar" / "api" / "client.py").exists():
+                return current
+            if current.parent == current:
+                break
+            current = current.parent
+    raise RuntimeError("Could not locate repository root containing custom_components/homgar")
+
+
+ROOT = _find_repo_root()
+
+
+def _load_module(module_name: str, relative_path: str):
+    path = ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load module from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# --- Minimal aiohttp stub (aiohttp is not a test-env dependency) -------------
+
+
+class _ClientTimeout:
+    def __init__(self, total=None, connect=None, sock_connect=None, sock_read=None):
+        self.total = total
+        self.connect = connect
+        self.sock_connect = sock_connect
+        self.sock_read = sock_read
+
+
+class _ClientSession:  # only needed for the type annotation in __init__
+    pass
+
+
+_aiohttp_stub = types.ModuleType("aiohttp")
+_aiohttp_stub.ClientTimeout = _ClientTimeout
+_aiohttp_stub.ClientSession = _ClientSession
+_aiohttp_stub.ClientError = type("ClientError", (Exception,), {})
+sys.modules["aiohttp"] = _aiohttp_stub
+
+sys.modules.setdefault("custom_components", types.ModuleType("custom_components"))
+sys.modules.setdefault("custom_components.homgar", types.ModuleType("custom_components.homgar"))
+sys.modules.setdefault("custom_components.homgar.api", types.ModuleType("custom_components.homgar.api"))
+_load_module("custom_components.homgar.const", "custom_components/homgar/const.py")
+client_mod = _load_module("custom_components.homgar.api.client", "custom_components/homgar/api/client.py")
+
+
+PASS = 0
+FAIL = 0
+
+
+def check(name: str, condition: bool, detail: str = "") -> None:
+    global PASS, FAIL
+    if condition:
+        print(f"  ✅ {name}")
+        PASS += 1
+    else:
+        print(f"  ❌ {name}{': ' + detail if detail else ''}")
+        FAIL += 1
+
+
+class _FakeResp:
+    def __init__(self, payload):
+        self._payload = payload
+        self.status = 200
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def json(self):
+        return self._payload
+
+    async def text(self):
+        return ""
+
+
+_LOGIN_PAYLOAD = {
+    "code": 0,
+    "ts": 1700000000000,
+    "data": {"token": "fresh-token", "refreshToken": "r", "tokenExpired": 3600, "user": {}},
+}
+
+
+class _SequencedSession:
+    """Returns login success for the login URL and a queue of payloads per URL.
+
+    Records the number of login POSTs so tests can assert whether a re-auth
+    happened.
+    """
+
+    def __init__(self, queues: dict[str, list]):
+        self._queues = {url: list(payloads) for url, payloads in queues.items()}
+        self.login_posts = 0
+        self.control_posts = 0
+
+    def _next(self, url):
+        if url.endswith("/auth/basic/app/login"):
+            self.login_posts += 1
+            return _FakeResp(_LOGIN_PAYLOAD)
+        self.control_posts += 1
+        for key, queue in self._queues.items():
+            if url.endswith(key) and queue:
+                return _FakeResp(queue.pop(0))
+        raise AssertionError(f"No queued response for {url}")
+
+    def post(self, url, **kwargs):
+        return self._next(url)
+
+    def get(self, url, **kwargs):
+        return self._next(url)
+
+
+def _make_client(queues):
+    session = _SequencedSession(queues)
+    client = client_mod.HomGarClient("31", "a@b.com", "pw", session, "homgar")
+    # Pretend we already have a (soon-to-be-rejected) token whose LOCAL clock is
+    # still valid, so ensure_logged_in() does not log in first — the stale token
+    # goes out and the server answers 1004.
+    client._token = "stale-token"
+    client._refresh_token = "stale-refresh"
+    client._token_expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
+    return client, session
+
+
+_TOKEN_ERROR = {"code": 1004, "msg": "token error"}
+_NOT_TOKEN = {"code": 1001, "msg": "NOT_TOKEN", "ts": 1784873946096}
+_OK = {"code": 0, "data": {"state": "open"}}
+
+
+async def _test_control_work_mode_reauths_on_1004():
+    client, session = _make_client({"/app/device/controlWorkMode": [_TOKEN_ERROR, _OK]})
+    result = await client.control_work_mode(
+        mid=1, addr=2, device_name="d", product_key="p", port=1, mode=1, duration=60,
+    )
+    check(
+        "control_work_mode recovers from 1004 (no exception)",
+        result == "open",
+        f"got {result!r}",
+    )
+    check(
+        "control_work_mode performed exactly one re-login",
+        session.login_posts == 1,
+        f"login_posts={session.login_posts}",
+    )
+    check(
+        "control_work_mode retried the control call once (2 control POSTs)",
+        session.control_posts == 2,
+        f"control_posts={session.control_posts}",
+    )
+
+
+async def _test_control_work_mode_dp_reauths_on_1004():
+    client, session = _make_client({"/app/device/controlWorkModeDP": [_TOKEN_ERROR, _OK]})
+    result = await client.control_work_mode_dp(
+        mid=1, addr=2, device_name="d", product_key="p", port=1, mode=1, duration=60, hid=99,
+    )
+    check(
+        "control_work_mode_dp recovers from 1004 (no exception)",
+        result == "open",
+        f"got {result!r}",
+    )
+    check(
+        "control_work_mode_dp performed exactly one re-login",
+        session.login_posts == 1,
+        f"login_posts={session.login_posts}",
+    )
+    check(
+        "control_work_mode_dp retried the control call once (2 control POSTs)",
+        session.control_posts == 2,
+        f"control_posts={session.control_posts}",
+    )
+
+
+async def _test_control_work_mode_no_reauth_on_success():
+    client, session = _make_client({"/app/device/controlWorkMode": [_OK]})
+    result = await client.control_work_mode(
+        mid=1, addr=2, device_name="d", product_key="p", port=1, mode=1, duration=60,
+    )
+    check("control_work_mode returns state on clean success", result == "open", f"got {result!r}")
+    check(
+        "control_work_mode does NOT re-login on a clean 0 response",
+        session.login_posts == 0,
+        f"login_posts={session.login_posts}",
+    )
+    check(
+        "control_work_mode issues a single control POST on success",
+        session.control_posts == 1,
+        f"control_posts={session.control_posts}",
+    )
+
+
+async def _test_control_work_mode_still_raises_on_other_error():
+    client, session = _make_client({"/app/device/controlWorkMode": [{"code": 99, "msg": "boom"}]})
+    raised = False
+    try:
+        await client.control_work_mode(
+            mid=1, addr=2, device_name="d", product_key="p", port=1, mode=1, duration=60,
+        )
+    except client_mod.HomGarApiError:
+        raised = True
+    check("control_work_mode still raises on a non-token error (code 99)", raised)
+    check(
+        "control_work_mode does not re-login on a non-token error",
+        session.login_posts == 0,
+        f"login_posts={session.login_posts}",
+    )
+
+
+async def _test_subscribe_status_reauths_on_1001():
+    """Shaun's exact MQTT-renewal failure: subscribeStatus -> code 1001 NOT_TOKEN."""
+    ok_payload = {"code": 0, "data": {"deviceName": "x", "productKey": "p"}}
+    client, session = _make_client({"/app/device/subscribeStatus": [_NOT_TOKEN, ok_payload]})
+    result = await client.subscribe_status(
+        hid=1, hubs=[{"deviceName": "d", "mid": 1, "productKey": "p", "hid": 1}],
+    )
+    check(
+        "subscribe_status recovers from 1001 NOT_TOKEN (no exception)",
+        result == {"deviceName": "x", "productKey": "p"},
+        f"got {result!r}",
+    )
+    check(
+        "subscribe_status performed exactly one re-login",
+        session.login_posts == 1,
+        f"login_posts={session.login_posts}",
+    )
+    check(
+        "subscribe_status retried once (2 subscribeStatus POSTs)",
+        session.control_posts == 2,
+        f"control_posts={session.control_posts}",
+    )
+
+
+async def _test_get_device_status_reauths_on_1004():
+    ok_payload = {"code": 0, "data": {"battery": 100}}
+    client, session = _make_client({"/app/device/getDeviceStatus": [_TOKEN_ERROR, ok_payload]})
+    result = await client.get_device_status(mid=1)
+    check(
+        "get_device_status recovers from 1004 (no exception)",
+        result == {"battery": 100},
+        f"got {result!r}",
+    )
+    check("get_device_status re-logged in once", session.login_posts == 1, f"login_posts={session.login_posts}")
+    check("get_device_status retried once", session.control_posts == 2, f"control_posts={session.control_posts}")
+
+
+async def _test_set_device_state_reauths_on_1004():
+    client, session = _make_client({"/app/device/setDeviceStatus": [_TOKEN_ERROR, {"code": 0}]})
+    result = await client.set_device_state(
+        home_id=1, device_name="d", mid=1, product_key="p", state={"port_1": True},
+    )
+    check("set_device_state recovers from 1004 (returns True)", result is True, f"got {result!r}")
+    check("set_device_state re-logged in once", session.login_posts == 1, f"login_posts={session.login_posts}")
+    check("set_device_state retried once", session.control_posts == 2, f"control_posts={session.control_posts}")
+
+
+async def _test_get_product_models_reauths_on_1004():
+    ok_payload = {"code": 0, "data": {"models": [{"id": 1}, {"id": 2}]}}
+    client, session = _make_client({"/app/common/core/productModel": [_TOKEN_ERROR, ok_payload]})
+    result = await client.get_product_models()
+    check(
+        "get_product_models recovers from 1004 (returns models, not [])",
+        result == [{"id": 1}, {"id": 2}],
+        f"got {result!r}",
+    )
+    check("get_product_models re-logged in once", session.login_posts == 1, f"login_posts={session.login_posts}")
+    check("get_product_models retried once", session.control_posts == 2, f"control_posts={session.control_posts}")
+
+
+def main() -> int:
+    print("Token re-auth / retry regression tests")
+    asyncio.run(_test_control_work_mode_reauths_on_1004())
+    asyncio.run(_test_control_work_mode_dp_reauths_on_1004())
+    asyncio.run(_test_control_work_mode_no_reauth_on_success())
+    asyncio.run(_test_control_work_mode_still_raises_on_other_error())
+    asyncio.run(_test_subscribe_status_reauths_on_1001())
+    asyncio.run(_test_get_device_status_reauths_on_1004())
+    asyncio.run(_test_set_device_state_reauths_on_1004())
+    asyncio.run(_test_get_product_models_reauths_on_1004())
+    print(f"\n{PASS} passed, {FAIL} failed")
+    return 1 if FAIL else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/run_token_sensor_tests.py
+++ b/tests/run_token_sensor_tests.py
@@ -1,0 +1,72 @@
+"""Token diagnostic sensor tests. Runs in the ha-test container against the
+deployed integration at /config (imports Home Assistant)."""
+import sys
+import types
+from datetime import datetime, timedelta, timezone
+
+sys.path.insert(0, "/config")
+
+from custom_components.homgar.const import DOMAIN  # noqa: E402
+
+from custom_components.homgar.diagnostic_token_sensors import (  # noqa: E402
+    HomGarTokenReauthCountSensor,
+    HomGarLastTokenReauthSensor,
+    HomGarTokenExpiresAtSensor,
+    build_token_diagnostic_sensors,
+)
+from homeassistant.components.sensor import SensorStateClass, SensorDeviceClass  # noqa: E402
+from homeassistant.const import EntityCategory  # noqa: E402
+
+PASS = 0
+FAIL = 0
+
+
+def check(name, cond, detail=""):
+    global PASS, FAIL
+    if cond:
+        print(f"  ✅ {name}"); PASS += 1
+    else:
+        print(f"  ❌ {name}{': ' + detail if detail else ''}"); FAIL += 1
+
+
+now = datetime.now(timezone.utc)
+expires = now + timedelta(days=38)
+client = types.SimpleNamespace(
+    reauth_count=7,
+    last_reauth_at=now,
+    last_reauth_trigger="subscribeStatus",
+    last_reauth_code=1001,
+    token_expires_at=expires,
+)
+coordinator = types.SimpleNamespace(_client=client, data={"hubs": []}, last_update_success=True)
+hub_info = {"mid": 12345, "name": "Hub", "model": "HWG023WBRF-V2"}
+ENTRY = "entry_abc"
+
+count = HomGarTokenReauthCountSensor(coordinator, hub_info, ENTRY)
+last = HomGarLastTokenReauthSensor(coordinator, hub_info, ENTRY)
+exp = HomGarTokenExpiresAtSensor(coordinator, hub_info, ENTRY)
+
+check("count native_value reads reauth_count", count.native_value == 7, f"got {count.native_value}")
+check("count is total_increasing", count.state_class == SensorStateClass.TOTAL_INCREASING)
+check("count is DIAGNOSTIC", count.entity_category == EntityCategory.DIAGNOSTIC)
+check("count enabled by default", count.entity_registry_enabled_default is True)
+check("count unique_id is entry-scoped",
+      count.unique_id == f"{ENTRY}_token_reauth_count", f"got {count.unique_id}")
+check("count attaches to hub device",
+      (DOMAIN, f"rainpoint_hub_12345") in count.device_info["identifiers"])
+
+check("last native_value is the reauth timestamp", last.native_value == now)
+check("last is timestamp device_class", last.device_class == SensorDeviceClass.TIMESTAMP)
+check("last exposes trigger attr",
+      last.extra_state_attributes.get("trigger_endpoint") == "subscribeStatus")
+check("last exposes error code attr",
+      last.extra_state_attributes.get("last_error_code") == 1001)
+
+check("expires native_value is token_expires_at", exp.native_value == expires)
+check("expires is timestamp device_class", exp.device_class == SensorDeviceClass.TIMESTAMP)
+
+built = build_token_diagnostic_sensors(coordinator, hub_info, ENTRY)
+check("factory returns exactly 3 sensors", len(built) == 3, f"got {len(built)}")
+
+print(f"\n{PASS} passed, {FAIL} failed")
+sys.exit(1 if FAIL else 0)


### PR DESCRIPTION
## Summary

Follow-up to v3.0.40 (the User-Agent 403 fix). Once requests reached the cloud again, [@shaundekok](https://github.com/shaundekok) hit two token failures that the read endpoints already handled but the rest did not:

- Valve control: `controlWorkMode failed: code=1004 msg=token error`
- MQTT renewal stuck in a loop: `subscribeStatus failed: {'code': 1001, 'msg': 'NOT_TOKEN'}`, retrying every 30–300s without recovering

### Root cause
Only the three list/status **read** endpoints re-authenticated and retried once on a server-rejected token. The other authenticated endpoints (`controlWorkMode`, `controlWorkModeDP`, `subscribeStatus`, `getDeviceStatus`, `setDeviceStatus`, `productModel`) raised or degraded. Because `ensure_logged_in()`/`_ensure_auth()` only check the **local** expiry clock, the cloud can reject a token (rotation, or the refresh path overstating lifetime) while HA still thinks it's valid — so coordinator reads silently re-authed and kept entities updating, while valve commands threw and the independent MQTT-renewal schedule spun in a `NOT_TOKEN` storm.

### Fix
Every authenticated endpoint now performs the same `1001/1004 → re-auth → retry once` recovery (no loop — a still-rejected retry falls through to a hard error). `controlWorkModeDP` rebuilds its `hid` header after re-auth.

### Diagnostics (to answer "token times out every minute")
The token is long-lived (~60-day server lifetime on the maintainer's account; 120s HTTP poll), so minute-scale rejection points to an *external* session invalidating the token, not expiry. To make this measurable on any user's HA, this PR adds three **local-only, enabled-by-default** DIAGNOSTIC sensors on the Hub device:

- **Token re-auth count** — `total_increasing`; history-graph slope = how often the cloud is rejecting the token
- **Last token re-auth** — timestamp, with `trigger_endpoint` / `last_error_code` attributes
- **Token expires at** — a far-future value confirms churn is external session invalidation, not expiry

No data leaves Home Assistant.

## Tests
- `tests/run_token_reauth_tests.py` (23) — recovery on all control/subscribe/status/set/product-model endpoints; clean responses never re-auth; non-token errors still raise
- `tests/run_token_diag_tests.py` (11) — `_reauth()` telemetry (count/timestamp/trigger/code)
- `tests/run_token_sensor_tests.py` (13) — sensor classes, device_class/state_class, Hub attach, factory
- All wired into the pre-commit Docker gate; full gate green (incl. 84/84 decoder + 23/23 recovery + 11/11 telemetry + 13/13 sensor). Deployed to a live HA container: 3 entities render on the Hub, `disabled_by: None`, 0 tracebacks.

## Notes
- Bumps manifest to `3.0.41`.
- Design spec and implementation plan included under `docs/superpowers/`.
- Re: #75, #76 (lineage — these are the User-Agent issues; this is the token-recovery follow-up).