### PR TITLE
v3.0.42 — single-zone valve legacy parsing (#81) + transient cloud retry (#82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.0.42] - 2026-08-04
+
+### 🐛 Bug Fixes
+- **Single-zone RF water timers (e.g. HTV103FRF) bridged through a weather-station gateway no longer report garbage** — when a one-zone valve like the RainPoint HTV103FRF is read through a Bresser HWS388WRF-V7 (and similar) gateway, the cloud returns a **legacy** payload (`1,-55,1;0,124,0,0,0,0`) rather than the usual TLV frame. The decoder only ran valve semantics for **multi-port** valves (`portNumber > 1`), so a single-port valve fell through to the generic weather-sensor parser. That parser reinterpreted the data array as air temperature/humidity/water fields, producing impossible readings: temperatures like `-16 °C` (a flow-rate value run through the °F→°C formula), humidity of `124%`/`480%` (the session-volume value), and a "Last Session Volume" of `60.00 L` that was actually the 600-second target duration. Single-port valves now decode with valve semantics on the legacy path too — `[0]` flow rate (÷10 L/min), `[1]` session volume (÷10 L), `[3]` start timestamp + `[4]` target duration → irrigation end time — and the phantom temperature/humidity entities are gone (multi-zone valves and the TLV path are unchanged). Thanks to [@mm060488](https://github.com/mm060488) for the app-verified payload decode. ([#81](https://github.com/brettmeyerowitz/homeassistant-homgar/issues/81))
+- **Transient cloud hiccups no longer flip entities Unavailable or spam the log** — the RainPoint cloud (`region3.homgarus.com`) intermittently returns connection timeouts, DNS timeouts, and HTTP 503s while the phone app keeps working and the next poll succeeds on its own. Previously any of these raised straight through: there was **no** network-level or 5xx retry anywhere (the existing `1001/1004` re-auth path only triggers on a `200` with a token-error body, so it can't cover a 503 or a DNS timeout). The API layer now retries transient network errors and 5xx responses with a short backoff (1s/2s/4s, comfortably inside the 120s poll), giving up only after the retries are exhausted. And when an individual device-status fetch still fails, the coordinator now **retains that hub's last-good status** for the cycle instead of substituting an empty reading — so entities hold their previous values through a passing blip rather than dropping to Unavailable. Thanks to [@thomasgraf99](https://github.com/thomasgraf99) for the detailed multi-error report. ([#82](https://github.com/brettmeyerowitz/homeassistant-homgar/issues/82))
+
+### 🧪 Tests
+- `tests/fixtures/payloads/HTV103FRF.json` — three app-verified legacy payloads (idle, watering, post-session) pin the single-zone valve decode: no temperature/humidity, correct flow rate, `12.4 L` session volume, and a computed irrigation end time. Runs in the fixture corpus.
+- `tests/run_transient_retry_tests.py` (22 checks) — a 503, a connection error, and a timeout each retry once then succeed; a persistent 503 gives up as `HomGarTransientError` after a bounded number of attempts with non-decreasing backoff; a `404` raises immediately without retry; a clean `200` never retries or sleeps.
+- `tests/run_coordinator_retention_tests.py` (3 checks) — a failed status fetch retains the prior reading, falls back to empty only when there is no prior reading, and never lets an empty prior masquerade as good data.
+- All three are wired into the pre-commit Docker gate.
+
+---
+
 ## [3.0.41] - 2026-07-24
 
 ### 🐛 Bug Fixes

--- a/custom_components/homgar/api/client.py
+++ b/custom_components/homgar/api/client.py
@@ -28,9 +28,27 @@ _REQUEST_TIMEOUT = aiohttp.ClientTimeout(total=30, connect=10, sock_connect=10)
 # value works; this mirrors the RainPoint/HomGar phone app. See issue #76.
 _USER_AGENT = "okhttp/4.9.2"
 
+# Transient upstream failures worth retrying within a single coordinator poll:
+# connection resets, DNS/connect timeouts, and 5xx from the cloud. The cloud
+# (region3.homgarus.com) intermittently returns these while the RainPoint app
+# keeps working; a short in-poll backoff lets a blip self-heal instead of
+# blanking entities or spamming the log. Total wait stays well inside the 120s
+# poll interval. See issue #82.
+_TRANSIENT_RETRY_BACKOFF = (1, 2, 4)  # seconds between attempts (3 retries)
+
+# aiohttp raises ClientError for connector/DNS/disconnect failures; connection
+# and server timeouts subclass asyncio.TimeoutError.
+_TRANSIENT_NETWORK_ERRORS = (aiohttp.ClientError, asyncio.TimeoutError)
+
 
 class HomGarApiError(Exception):
     pass
+
+
+class HomGarTransientError(HomGarApiError):
+    """A transient upstream failure (network error or 5xx) that outlived its
+    retries. Kept distinct so callers can tell a passing cloud blip from a
+    genuine API/protocol error."""
 
 
 class HomGarClient:
@@ -88,6 +106,53 @@ class HomGarClient:
         # Force the app User-Agent last so it always overrides HA's session default.
         kwargs["headers"] = {**(kwargs.get("headers") or {}), "User-Agent": _USER_AGENT}
         return self._session.post(url, **kwargs)
+
+    async def _request_json(self, method: str, url: str, *, what: str,
+                            retry: bool = True, **kwargs) -> dict:
+        """Perform an HTTP request and return the parsed JSON body, retrying
+        transient upstream failures with a short backoff.
+
+        Transient = a network error (connection reset, DNS/connect timeout) or a
+        5xx response. When ``retry`` is true these are retried up to
+        ``len(_TRANSIENT_RETRY_BACKOFF)`` times; if still failing, a
+        ``HomGarTransientError`` is raised so the coordinator surfaces a single
+        ``UpdateFailed`` (which preserves last-good state) rather than treating
+        the blip as a real error mid-poll.
+
+        ``retry`` is false for write/control endpoints (valve open/close, set
+        state): those commands are absolute ("run for N seconds"), not
+        idempotent, so a post-send disconnect must NOT auto-resend and risk
+        re-actuating irrigation. They fail fast; a transient failure still
+        raises ``HomGarTransientError`` immediately.
+
+        Any other non-200 (e.g. 4xx) raises ``HomGarApiError`` immediately and is
+        never retried. This centralises the timeout + retry policy; callers keep
+        their own ``code``/token-reauth handling on the returned dict.
+        """
+        opener = self._get if method == "get" else self._post
+        attempts = len(_TRANSIENT_RETRY_BACKOFF) + 1 if retry else 1
+        last_error: HomGarTransientError | None = None
+        for attempt in range(attempts):
+            try:
+                async with opener(url, **kwargs) as resp:
+                    if resp.status >= 500:
+                        raise HomGarTransientError(f"{what} HTTP {resp.status}")
+                    if resp.status != 200:
+                        raise HomGarApiError(f"{what} HTTP {resp.status}")
+                    return await resp.json()
+            except _TRANSIENT_NETWORK_ERRORS as err:
+                last_error = HomGarTransientError(f"{what}: {err}")
+            except HomGarTransientError as err:
+                last_error = err
+            if attempt + 1 < attempts:
+                delay = _TRANSIENT_RETRY_BACKOFF[attempt]
+                _LOGGER.debug(
+                    "%s transient failure (attempt %d/%d), retrying in %ss: %s",
+                    what, attempt + 1, attempts, delay, last_error,
+                )
+                await asyncio.sleep(delay)
+        _LOGGER.warning("%s failed after %d attempts: %s", what, attempts, last_error)
+        raise last_error
 
     # --- token state helpers ---
 
@@ -336,15 +401,11 @@ class HomGarClient:
         _LOGGER.debug("API call: list_homes URL=%s", url)
 
         used_token = self._token
-        async with self._get(url, headers=self._auth_headers()) as resp:
-            if resp.status != 200:
-                raise HomGarApiError(f"list_homes HTTP {resp.status}")
-            data = await resp.json()
-            _LOGGER.debug("API response: list_homes data=%s", data)
+        data = await self._request_json("get", url, what="list_homes", headers=self._auth_headers())
+        _LOGGER.debug("API response: list_homes data=%s", data)
         if data.get("code") in (1001, 1004):
             await self._reauth(trigger="list_homes", code=data.get("code"), rejected_token=used_token)
-            async with self._get(url, headers=self._auth_headers()) as resp2:
-                data = await resp2.json()
+            data = await self._request_json("get", url, what="list_homes", headers=self._auth_headers())
         if data.get("code") != 0:
             raise HomGarApiError(f"list_homes failed: {data}")
         return data.get("data", [])
@@ -356,15 +417,15 @@ class HomGarClient:
         params = {"hid": hid}
         _LOGGER.debug("API call: get_devices_by_hid URL=%s params=%s", url, params)
         used_token = self._token
-        async with self._get(url, headers=self._auth_headers(), params=params) as resp:
-            if resp.status != 200:
-                raise HomGarApiError(f"getDeviceByHid HTTP {resp.status}")
-            data = await resp.json()
+        data = await self._request_json(
+            "get", url, what="getDeviceByHid", headers=self._auth_headers(), params=params
+        )
         _LOGGER.debug("API response: get_devices_by_hid data=%s", data)
         if data.get("code") in (1001, 1004):
             await self._reauth(trigger="getDeviceByHid", code=data.get("code"), rejected_token=used_token)
-            async with self._get(url, headers=self._auth_headers(), params=params) as resp2:
-                data = await resp2.json()
+            data = await self._request_json(
+                "get", url, what="getDeviceByHid", headers=self._auth_headers(), params=params
+            )
         if data.get("code") != 0:
             raise HomGarApiError(f"getDeviceByHid failed: {data}")
         return data.get("data", [])
@@ -386,15 +447,15 @@ class HomGarClient:
         payload = {"devices": device_list}
         _LOGGER.debug("API call: get_multiple_device_status URL=%s payload=%s", url, payload)
         used_token = self._token
-        async with self._post(url, headers=self._auth_headers(), json=payload) as resp:
-            if resp.status != 200:
-                raise HomGarApiError(f"Failed to get device status: {resp.status}")
-            data = await resp.json()
+        data = await self._request_json(
+            "post", url, what="multipleDeviceStatus", headers=self._auth_headers(), json=payload
+        )
         _LOGGER.debug("API response: get_multiple_device_status data=%s", data)
         if data.get("code") in (1001, 1004):
             await self._reauth(trigger="multipleDeviceStatus", code=data.get("code"), rejected_token=used_token)
-            async with self._post(url, headers=self._auth_headers(), json=payload) as resp2:
-                data = await resp2.json()
+            data = await self._request_json(
+                "post", url, what="multipleDeviceStatus", headers=self._auth_headers(), json=payload
+            )
         if data.get("code") != 0:
             raise HomGarApiError(f"Device status API error: {data.get('msg')}")
         
@@ -418,17 +479,15 @@ class HomGarClient:
         params = {"mid": mid}
         _LOGGER.debug("API call: get_device_status URL=%s params=%s", url, params)
         used_token = self._token
-        async with self._get(url, headers=self._auth_headers(), params=params) as resp:
-            if resp.status != 200:
-                raise HomGarApiError(f"getDeviceStatus HTTP {resp.status}")
-            data = await resp.json()
+        data = await self._request_json(
+            "get", url, what="getDeviceStatus", headers=self._auth_headers(), params=params
+        )
         _LOGGER.debug("API response: get_device_status data=%s", data)
         if data.get("code") in (1001, 1004):
             await self._reauth(trigger="getDeviceStatus", code=data.get("code"), rejected_token=used_token)
-            async with self._get(url, headers=self._auth_headers(), params=params) as resp2:
-                if resp2.status != 200:
-                    raise HomGarApiError(f"getDeviceStatus HTTP {resp2.status}")
-                data = await resp2.json()
+            data = await self._request_json(
+                "get", url, what="getDeviceStatus", headers=self._auth_headers(), params=params
+            )
         if data.get("code") != 0:
             raise HomGarApiError(f"getDeviceStatus failed: {data}")
         return data.get("data", {})
@@ -482,20 +541,18 @@ class HomGarClient:
         }
         _LOGGER.debug("API call: subscribe_status URL=%s payload=%s", url, payload)
         used_token = self._token
-        async with self._post(url, headers=self._auth_headers(), json=payload) as resp:
-            if resp.status != 200:
-                raise HomGarApiError(f"subscribeStatus HTTP {resp.status}")
-            data = await resp.json()
+        data = await self._request_json(
+            "post", url, what="subscribeStatus", headers=self._auth_headers(), json=payload
+        )
         _LOGGER.debug("API response: subscribe_status data=%s", data)
         # A rejected token (1001 NOT_TOKEN / 1004) here strands the periodic MQTT
         # renewal in a retry storm, since ensure_auth only checks the local clock.
         # Re-auth and retry once, as the read endpoints do.
         if data.get("code") in (1001, 1004):
             await self._reauth(trigger="subscribeStatus", code=data.get("code"), rejected_token=used_token)
-            async with self._post(url, headers=self._auth_headers(), json=payload) as resp2:
-                if resp2.status != 200:
-                    raise HomGarApiError(f"subscribeStatus HTTP {resp2.status}")
-                data = await resp2.json()
+            data = await self._request_json(
+                "post", url, what="subscribeStatus", headers=self._auth_headers(), json=payload
+            )
             _LOGGER.debug("API response (after reauth): subscribe_status data=%s", data)
         if data.get("code") != 0:
             raise HomGarApiError(f"subscribeStatus failed: {data}")
@@ -513,16 +570,14 @@ class HomGarClient:
             "status": state,
         }
         used_token = self._token
-        async with self._post(url, headers=self._auth_headers(), json=payload) as resp:
-            if resp.status != 200:
-                raise HomGarApiError(f"Failed to set device state: {resp.status}")
-            data = await resp.json()
+        data = await self._request_json(
+            "post", url, what="setDeviceStatus", retry=False, headers=self._auth_headers(), json=payload
+        )
         if data.get("code") in (1001, 1004):
             await self._reauth(trigger="setDeviceStatus", code=data.get("code"), rejected_token=used_token)
-            async with self._post(url, headers=self._auth_headers(), json=payload) as resp2:
-                if resp2.status != 200:
-                    raise HomGarApiError(f"Failed to set device state: {resp2.status}")
-                data = await resp2.json()
+            data = await self._request_json(
+                "post", url, what="setDeviceStatus", retry=False, headers=self._auth_headers(), json=payload
+            )
         if data.get("code") != 0:
             raise HomGarApiError(f"Set device state API error: {data.get('msg')}")
         return True
@@ -538,19 +593,17 @@ class HomGarClient:
         
         _LOGGER.debug("API call: get_product_models URL=%s params=%s", url, params)
         used_token = self._token
-        async with self._get(url, headers=self._auth_headers(), params=params) as resp:
-            if resp.status != 200:
-                raise HomGarApiError(f"2026-04-10 21:22:21.337 DEBUG (MainThread) [custom_components.homgar.api.client] API call: get_product_models URL=https://region3.homgarus.com/app/common/core/productModel params={'version': 0} HTTP {resp.status}")
-            data = await resp.json()
+        data = await self._request_json(
+            "get", url, what="get_product_models", headers=self._auth_headers(), params=params
+        )
 
         _LOGGER.warning("API response: get_product_models received, code=%s", data.get('code'))
 
         if isinstance(data, dict) and data.get("code") in (1001, 1004):
             await self._reauth(trigger="productModel", code=data.get("code"), rejected_token=used_token)
-            async with self._get(url, headers=self._auth_headers(), params=params) as resp2:
-                if resp2.status != 200:
-                    raise HomGarApiError(f"get_product_models HTTP {resp2.status}")
-                data = await resp2.json()
+            data = await self._request_json(
+                "get", url, what="get_product_models", headers=self._auth_headers(), params=params
+            )
             _LOGGER.warning("API response (after reauth): get_product_models code=%s",
                             data.get('code') if isinstance(data, dict) else None)
 
@@ -657,10 +710,9 @@ class HomGarClient:
         _LOGGER.debug("API call: control_work_mode URL=%s payload=%s", url, payload)
 
         used_token = self._token
-        async with self._post(url, json=payload, headers=self._auth_headers()) as resp:
-            if resp.status != 200:
-                raise HomGarApiError(f"controlWorkMode HTTP {resp.status}")
-            data = await resp.json()
+        data = await self._request_json(
+            "post", url, what="controlWorkMode", retry=False, json=payload, headers=self._auth_headers()
+        )
 
         _LOGGER.debug("API response: control_work_mode data=%s", data)
 
@@ -671,10 +723,9 @@ class HomGarClient:
         # actually reach the cloud.
         if data.get("code") in (1001, 1004):
             await self._reauth(trigger="controlWorkMode", code=data.get("code"), rejected_token=used_token)
-            async with self._post(url, json=payload, headers=self._auth_headers()) as resp2:
-                if resp2.status != 200:
-                    raise HomGarApiError(f"controlWorkMode HTTP {resp2.status}")
-                data = await resp2.json()
+            data = await self._request_json(
+                "post", url, what="controlWorkMode", retry=False, json=payload, headers=self._auth_headers()
+            )
             _LOGGER.debug("API response (after reauth): control_work_mode data=%s", data)
 
         code = data.get("code")
@@ -722,10 +773,9 @@ class HomGarClient:
         _LOGGER.debug("API call: control_work_mode_dp URL=%s payload=%s", url, payload)
 
         used_token = self._token
-        async with self._post(url, json=payload, headers=headers) as resp:
-            if resp.status != 200:
-                raise HomGarApiError(f"controlWorkModeDP HTTP {resp.status}")
-            data = await resp.json()
+        data = await self._request_json(
+            "post", url, what="controlWorkModeDP", retry=False, json=payload, headers=headers
+        )
 
         _LOGGER.debug("API response: control_work_mode_dp data=%s", data)
 
@@ -739,10 +789,9 @@ class HomGarClient:
             headers = self._auth_headers()
             if hid is not None:
                 headers["hid"] = str(hid)
-            async with self._post(url, json=payload, headers=headers) as resp2:
-                if resp2.status != 200:
-                    raise HomGarApiError(f"controlWorkModeDP HTTP {resp2.status}")
-                data = await resp2.json()
+            data = await self._request_json(
+                "post", url, what="controlWorkModeDP", retry=False, json=payload, headers=headers
+            )
             _LOGGER.debug("API response (after reauth): control_work_mode_dp data=%s", data)
 
         code = data.get("code")

--- a/custom_components/homgar/coordinator.py
+++ b/custom_components/homgar/coordinator.py
@@ -86,6 +86,36 @@ def _hub_metadata_score(hub: dict) -> int:
     )
 
 
+# How many consecutive failed status fetches a hub may coast on last-good data
+# before it is finally blanked (→ entities Unavailable). At the 120s poll
+# interval this is ~10 minutes: long enough to ride out a passing cloud blip,
+# short enough that a genuine outage still surfaces instead of showing stale
+# "watering" state forever. See issue #82.
+_MAX_STALE_STATUS_POLLS = 5
+
+
+def _status_on_fetch_failure(
+    previous_status: dict | None, consecutive_misses: int, max_misses: int
+) -> dict:
+    """Choose the status to use for a hub whose status fetch failed this poll.
+
+    A transient failure (e.g. an exhausted 503/timeout) should not immediately
+    blank the hub: substituting an empty status list flips every entity on it
+    Unavailable for a cycle. Retain the previous poll's status so entities hold
+    their last-good values through a passing cloud blip — but only up to
+    ``max_misses`` consecutive failures, after which the hub is blanked so a
+    genuine, sustained outage stops being masked. Also blanks when there is no
+    prior reading. See issue #82.
+    """
+    if (
+        previous_status
+        and previous_status.get("subDeviceStatus")
+        and consecutive_misses <= max_misses
+    ):
+        return previous_status
+    return {"subDeviceStatus": []}
+
+
 def _hub_identity_keys(hub: dict) -> set[tuple[str, str]]:
     """Return stable cloud identity keys that can reveal duplicate hub rows."""
     keys: set[tuple[str, str]] = set()
@@ -112,6 +142,9 @@ class HomGarCoordinator(DataUpdateCoordinator):
         self._notified_unknown_models: set[str] = set()
         self._mqtt_diagnostics: dict[str, dict] = {}
         self._last_good_data: dict[str, dict] = {}
+        # Consecutive failed status fetches per hub mid, used to cap how long a
+        # hub may coast on retained last-good status. See _status_on_fetch_failure.
+        self._status_miss_count: dict[int, int] = {}
     
     async def handle_mqtt_update(self, data: dict) -> None:
         """Handle MQTT message for real-time valve updates."""
@@ -203,6 +236,7 @@ class HomGarCoordinator(DataUpdateCoordinator):
                         mid = device_data["mid"]
                         status_array = device_data.get("subDeviceStatus", [])
                         status_by_mid[mid] = {"subDeviceStatus": status_array}
+                        self._status_miss_count.pop(mid, None)  # fresh reading clears the staleness cap
                         _LOGGER.debug("Fetched status for mid=%s using multipleDeviceStatus", mid)
                         
                 except Exception as e:
@@ -214,10 +248,25 @@ class HomGarCoordinator(DataUpdateCoordinator):
                         try:
                             status = await self._client.get_device_status(mid)
                             status_by_mid[mid] = status
+                            self._status_miss_count.pop(mid, None)  # fresh reading clears the staleness cap
                             _LOGGER.debug("Fetched status for mid=%s using individual call", mid)
                         except Exception as individual_e:
-                            _LOGGER.error("Failed to get status for mid=%s: %s", mid, individual_e)
-                            status_by_mid[mid] = {"subDeviceStatus": []}
+                            # Transient upstream failure: keep the hub's last-good
+                            # status instead of blanking its entities for a cycle,
+                            # but only up to _MAX_STALE_STATUS_POLLS so a sustained
+                            # outage still surfaces. See issue #82.
+                            misses = self._status_miss_count.get(mid, 0) + 1
+                            self._status_miss_count[mid] = misses
+                            prev = (self.data or {}).get("status", {}).get(mid)
+                            retained = _status_on_fetch_failure(prev, misses, _MAX_STALE_STATUS_POLLS)
+                            if retained.get("subDeviceStatus"):
+                                _LOGGER.warning(
+                                    "Failed to get status for mid=%s (miss %d/%d), retaining last-good reading: %s",
+                                    mid, misses, _MAX_STALE_STATUS_POLLS, individual_e,
+                                )
+                            else:
+                                _LOGGER.error("Failed to get status for mid=%s: %s", mid, individual_e)
+                            status_by_mid[mid] = retained
 
             for hub in hubs:
                 mid = hub["mid"]

--- a/custom_components/homgar/decoder.py
+++ b/custom_components/homgar/decoder.py
@@ -512,6 +512,60 @@ def _decode_legacy_port_section(section: str, unit: str) -> dict:
     return result
 
 
+def _decode_legacy_single_zone_valve(section: str, unit: str) -> dict:
+    """Decode a single-zone RF water-timer legacy payload (e.g. HTV103FRF).
+
+    Bridged through a weather-station gateway (e.g. a Bresser HWS388WRF-V7),
+    single-port valves emit a *legacy* payload. Its data array is neither the
+    temperature/humidity layout of a weather sensor nor the work-mode section
+    layout of a multi-zone valve — routing it through either produces bogus
+    negative temperatures and >100% humidity. The real layout is:
+
+      [0] flow rate        tenths of L/min  (0 when the valve is closed)
+      [1] session volume   tenths of L      (last / current session)
+      [2] reserved
+      [3] start_ts         Unix epoch of the current/last irrigation start
+      [4] target_duration  seconds
+      [5] reserved
+
+    Reported and app-verified in issue #81.
+    """
+    result: dict = {}
+    fields = section.split(",")
+
+    def fi(idx):
+        try:
+            v = fields[idx].strip()
+            if "(" in v:
+                v = v[:v.index("(")]
+            return int(v)
+        except (IndexError, ValueError):
+            return None
+
+    flow_raw = fi(0)
+    vol_raw = fi(1)
+    start_ts = fi(3)
+    dur_s = fi(4)
+
+    watering = bool(flow_raw)
+    result["is_watering"] = watering
+    result["valve_state"] = "irrigation" if watering else "idle"
+
+    if flow_raw is not None:
+        result["flow_rate"] = round(flow_raw / 10.0, 1)
+    if vol_raw is not None:
+        result["last_water_volume"] = _vol(vol_raw, unit)
+    if dur_s:
+        result["current_session_duration"] = dur_s
+    if start_ts and start_ts > 1_000_000_000:
+        end_ts = start_ts + (dur_s or 0)
+        result["irrigation_end_time"] = datetime.fromtimestamp(
+            end_ts, tz=timezone.utc
+        ).isoformat()
+
+    return result
+
+
 def _decode_legacy_fields(leg: dict, unit: str, temp_unit: str,
                           port_number: int = 1, model_str: str = "") -> dict:
     result: dict = {}
@@ -519,16 +573,20 @@ def _decode_legacy_fields(leg: dict, unit: str, temp_unit: str,
     is_display_hub_v2 = model_str == "HWS019WRF-V2"
     port_sections = leg.get("_leg_port_sections", [])
     has_multi_port_sections = port_number > 1 and len(port_sections) >= port_number
+    # A single-port valve reporting a legacy payload (bridged via a weather
+    # gateway) must use valve semantics, not the weather/positional parser.
+    is_single_zone_valve = is_valve_model and port_number == 1
+    suppress_weather = (is_valve_model and has_multi_port_sections) or is_single_zone_valve
 
-    if not (is_valve_model and has_multi_port_sections) and "_leg_temp_raw" in leg:
+    if not suppress_weather and "_leg_temp_raw" in leg:
         v = _leg_temp_display(leg["_leg_temp_raw"], temp_unit)
         if v is not None:
             result["temperature"] = v
 
-    if not (is_valve_model and has_multi_port_sections) and "_leg_rh" in leg and leg["_leg_rh"] is not None:
+    if not suppress_weather and "_leg_rh" in leg and leg["_leg_rh"] is not None:
         result["humidity"] = leg["_leg_rh"]
 
-    if not (is_valve_model and has_multi_port_sections) and "_leg_pressure_raw" in leg and leg["_leg_pressure_raw"] is not None:
+    if not suppress_weather and "_leg_pressure_raw" in leg and leg["_leg_pressure_raw"] is not None:
         result["air_pressure"] = round(leg["_leg_pressure_raw"] / 10.0, 1)
 
     if "_leg_co2" in leg and leg["_leg_co2"] is not None:
@@ -554,7 +612,7 @@ def _decode_legacy_fields(leg: dict, unit: str, temp_unit: str,
     if "_leg_illuminance_raw10" in leg and leg["_leg_illuminance_raw10"] is not None:
         result["illuminance"] = round(leg["_leg_illuminance_raw10"] / 10.0, 1)
 
-    if not (is_valve_model and has_multi_port_sections):
+    if not suppress_weather:
         if leg.get("_leg_cur_water_raw") is not None:
             result["current_water_volume"] = _vol(leg["_leg_cur_water_raw"], unit)
         if leg.get("_leg_last_usage_raw") is not None:
@@ -598,6 +656,9 @@ def _decode_legacy_fields(leg: dict, unit: str, temp_unit: str,
             section = port_sections[p - 1]
             if section:
                 result[f"port_{p}"] = _decode_legacy_port_section(section, unit)
+
+    if is_single_zone_valve and port_sections:
+        result.update(_decode_legacy_single_zone_valve(port_sections[0], unit))
 
     return result
 

--- a/custom_components/homgar/manifest.json
+++ b/custom_components/homgar/manifest.json
@@ -13,5 +13,5 @@
         "custom_components.homgar"
     ],
     "requirements": ["paho-mqtt>=1.6.0"],
-    "version": "3.0.41"
+    "version": "3.0.42"
 }

--- a/scripts/pre-commit-docker-test.sh
+++ b/scripts/pre-commit-docker-test.sh
@@ -319,6 +319,26 @@ else
     exit 1
 fi
 
+# ── Test: transient-error retry/backoff (issue #82) ───────────────────────
+echo "🧪 Running transient-error retry tests..."
+docker cp tests/run_transient_retry_tests.py ha-test:/tmp/tests/run_transient_retry_tests.py > /dev/null
+if docker exec ha-test python3 /tmp/tests/run_transient_retry_tests.py; then
+    echo "✅ Transient-error retry tests passed"
+else
+    echo "❌ ERROR: Transient-error retry tests failed"
+    exit 1
+fi
+
+# ── Test: coordinator last-good retention (issue #82) ─────────────────────
+echo "🧪 Running coordinator retention tests..."
+docker cp tests/run_coordinator_retention_tests.py ha-test:/tmp/run_coordinator_retention_tests.py > /dev/null
+if docker exec ha-test python3 /tmp/run_coordinator_retention_tests.py; then
+    echo "✅ Coordinator retention tests passed"
+else
+    echo "❌ ERROR: Coordinator retention tests failed"
+    exit 1
+fi
+
 # ── Test: decoder regression suite (scripts/test_decoders.py) ─────────────
 echo "🧪 Running decoder regression suite..."
 docker cp scripts/test_decoders.py ha-test:/tmp/test_decoders.py > /dev/null

--- a/tests/fixtures/payload_index.json
+++ b/tests/fixtures/payload_index.json
@@ -9,6 +9,7 @@
     {"model": "HCS030FRF", "file": "payloads/HCS030FRF.json", "sample_count": 1},
     {"model": "HCS0528ARF", "file": "payloads/HCS0528ARF.json", "sample_count": 2},
     {"model": "HCS0565ARF", "file": "payloads/HCS0565ARF.json", "sample_count": 2},
+    {"model": "HTV103FRF", "file": "payloads/HTV103FRF.json", "sample_count": 3},
     {"model": "HTV113FRF", "file": "payloads/HTV113FRF.json", "sample_count": 8},
     {"model": "HTV213FRF", "file": "payloads/HTV213FRF.json", "sample_count": 10},
     {"model": "HTV245FRF", "file": "payloads/HTV245FRF.json", "sample_count": 6},

--- a/tests/fixtures/payloads/HTV103FRF.json
+++ b/tests/fixtures/payloads/HTV103FRF.json
@@ -1,0 +1,58 @@
+{
+  "model": "HTV103FRF",
+  "samples": [
+    {
+      "id": "idle-before-session",
+      "source_issue": 81,
+      "source_type": "reporter_app_verified",
+      "format": "legacy",
+      "note": "Single-zone RF timer bridged via a Bresser HWS388WRF-V7 gateway emits a legacy payload. data=[flow, session_vol, _, start_ts, target_dur, _]. Idle: flow 0, no active session.",
+      "payload": "1,-54,1;0,480,0,0,0,0",
+      "expected": {
+        "temperature": {"present": false},
+        "humidity": {"present": false},
+        "is_watering": false,
+        "valve_state": "idle",
+        "flow_rate": 0.0,
+        "last_water_volume": 48.0,
+        "current_session_duration": {"present": false},
+        "irrigation_end_time": {"present": false}
+      }
+    },
+    {
+      "id": "watering-10min",
+      "source_issue": 81,
+      "source_type": "reporter_app_verified",
+      "format": "legacy",
+      "note": "Active 10-minute session: flow 3.3 L/min, start ts + 600s target duration -> end time.",
+      "payload": "1,-56,1;33,124,0,1784996333,600,0",
+      "expected": {
+        "temperature": {"present": false},
+        "humidity": {"present": false},
+        "is_watering": true,
+        "valve_state": "irrigation",
+        "flow_rate": 3.3,
+        "last_water_volume": 12.4,
+        "current_session_duration": 600,
+        "irrigation_end_time": "2026-07-25T16:28:53+00:00"
+      }
+    },
+    {
+      "id": "closed-after-session-12L",
+      "source_issue": 81,
+      "source_type": "reporter_app_verified",
+      "format": "legacy",
+      "note": "Directly after the session: official app reports 12.4 L consumed (data[1]=124 -> /10).",
+      "payload": "1,-55,1;0,124,0,0,0,0",
+      "expected": {
+        "temperature": {"present": false},
+        "humidity": {"present": false},
+        "is_watering": false,
+        "valve_state": "idle",
+        "flow_rate": 0.0,
+        "last_water_volume": 12.4,
+        "irrigation_end_time": {"present": false}
+      }
+    }
+  ]
+}

--- a/tests/run_coordinator_retention_tests.py
+++ b/tests/run_coordinator_retention_tests.py
@@ -1,0 +1,75 @@
+"""Regression test: the coordinator retains last-good hub status on a transient
+fetch failure instead of blanking it.
+
+Issue #82: when an individual getDeviceStatus call fails (e.g. an exhausted 503
+after retries), the coordinator substituted an empty status list, which made
+every entity on that hub flip Unavailable for a poll cycle. It should instead
+reuse the previous poll's status for that hub so entities hold their last-good
+values through a passing cloud blip.
+
+Runs in the ha-test container against the deployed integration at /config.
+"""
+import sys
+
+sys.path.insert(0, "/config")
+
+from custom_components.homgar.coordinator import (  # noqa: E402
+    _status_on_fetch_failure,
+    _MAX_STALE_STATUS_POLLS,
+)
+
+PASS = 0
+FAIL = 0
+
+
+def check(name, cond, detail=""):
+    global PASS, FAIL
+    if cond:
+        print(f"  ✅ {name}"); PASS += 1
+    else:
+        print(f"  ❌ {name}{': ' + detail if detail else ''}"); FAIL += 1
+
+
+MAX = _MAX_STALE_STATUS_POLLS
+prior = {"subDeviceStatus": [{"id": "D5", "value": "1,-55,1;0,124,0,0,0,0"}]}
+
+# A brief blip (first few consecutive misses) retains the prior reading verbatim
+# so entities hold last-good values instead of flicking Unavailable.
+check(
+    "retains prior status on the first miss",
+    _status_on_fetch_failure(prior, 1, MAX) == prior,
+    f"got {_status_on_fetch_failure(prior, 1, MAX)!r}",
+)
+check(
+    "still retains at the miss threshold",
+    _status_on_fetch_failure(prior, MAX, MAX) == prior,
+    f"got {_status_on_fetch_failure(prior, MAX, MAX)!r}",
+)
+
+# A persistent outage must eventually stop masking the problem: once the misses
+# exceed the cap, blank the hub so its entities go Unavailable (a visible signal)
+# rather than showing stale "watering" state forever.
+check(
+    "blanks once misses exceed the cap",
+    _status_on_fetch_failure(prior, MAX + 1, MAX) == {"subDeviceStatus": []},
+    f"got {_status_on_fetch_failure(prior, MAX + 1, MAX)!r}",
+)
+
+# No prior reading (first poll, or never succeeded) -> empty, not a crash.
+check(
+    "falls back to empty status when there is no prior reading",
+    _status_on_fetch_failure(None, 1, MAX) == {"subDeviceStatus": []},
+    f"got {_status_on_fetch_failure(None, 1, MAX)!r}",
+)
+
+# A prior status that itself was empty must not masquerade as good data.
+check(
+    "an empty prior status stays empty",
+    _status_on_fetch_failure({"subDeviceStatus": []}, 1, MAX) == {"subDeviceStatus": []},
+    f"got {_status_on_fetch_failure({'subDeviceStatus': []}, 1, MAX)!r}",
+)
+
+check("cap is a sane bounded number of polls (2-30)", 2 <= MAX <= 30, f"MAX={MAX}")
+
+print(f"\n{PASS} passed, {FAIL} failed")
+sys.exit(1 if FAIL else 0)

--- a/tests/run_transient_retry_tests.py
+++ b/tests/run_transient_retry_tests.py
@@ -1,0 +1,320 @@
+"""Regression tests: the API client retries transient upstream failures.
+
+Issue #82: intermittent connection timeouts, DNS timeouts and HTTP 503 from
+region3.homgarus.com surfaced as hard coordinator errors (entities flicking
+Unavailable, error-log spam) even though the RainPoint cloud recovered on its
+own moments later. The client now retries transient network errors and 5xx
+responses with a short backoff, only giving up (raising HomGarTransientError)
+after the retries are exhausted. Non-transient responses (4xx) still raise
+immediately, and clean 200s never retry.
+
+This runner avoids pytest so it runs on the host and in the ha-test container
+with only the standard library.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+import types
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+
+def _find_repo_root() -> Path:
+    candidates = [Path(__file__).resolve().parent, Path.cwd(), Path("/config")]
+    for start in candidates:
+        current = start
+        while True:
+            if (current / "custom_components" / "homgar" / "api" / "client.py").exists():
+                return current
+            if current.parent == current:
+                break
+            current = current.parent
+    raise RuntimeError("Could not locate repository root containing custom_components/homgar")
+
+
+ROOT = _find_repo_root()
+
+
+def _load_module(module_name: str, relative_path: str):
+    path = ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load module from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# --- Minimal aiohttp stub (aiohttp is not a test-env dependency) -------------
+
+
+class _ClientTimeout:
+    def __init__(self, total=None, connect=None, sock_connect=None, sock_read=None):
+        self.total = total
+        self.connect = connect
+
+
+_aiohttp_stub = types.ModuleType("aiohttp")
+_aiohttp_stub.ClientTimeout = _ClientTimeout
+_aiohttp_stub.ClientSession = type("ClientSession", (), {})
+_aiohttp_stub.ClientError = type("ClientError", (Exception,), {})
+# Connection/DNS failures subclass ClientError, matching real aiohttp.
+_aiohttp_stub.ClientConnectionError = type("ClientConnectionError", (_aiohttp_stub.ClientError,), {})
+_aiohttp_stub.ClientConnectorError = type("ClientConnectorError", (_aiohttp_stub.ClientConnectionError,), {})
+sys.modules["aiohttp"] = _aiohttp_stub
+
+sys.modules.setdefault("custom_components", types.ModuleType("custom_components"))
+sys.modules.setdefault("custom_components.homgar", types.ModuleType("custom_components.homgar"))
+sys.modules.setdefault("custom_components.homgar.api", types.ModuleType("custom_components.homgar.api"))
+_load_module("custom_components.homgar.const", "custom_components/homgar/const.py")
+client_mod = _load_module("custom_components.homgar.api.client", "custom_components/homgar/api/client.py")
+
+
+PASS = 0
+FAIL = 0
+
+
+def check(name: str, condition: bool, detail: str = "") -> None:
+    global PASS, FAIL
+    if condition:
+        print(f"  ✅ {name}")
+        PASS += 1
+    else:
+        print(f"  ❌ {name}{': ' + detail if detail else ''}")
+        FAIL += 1
+
+
+_LOGIN_PAYLOAD = {
+    "code": 0, "ts": 1700000000000,
+    "data": {"token": "fresh", "refreshToken": "r", "tokenExpired": 3600, "user": {}},
+}
+
+
+class _FakeResp:
+    def __init__(self, status, payload):
+        self.status = status
+        self._payload = payload
+
+    async def json(self):
+        return self._payload
+
+    async def text(self):
+        return ""
+
+
+class _FakeReqCtx:
+    """Async context manager whose entry either raises or yields a response."""
+
+    def __init__(self, action):
+        self._action = action  # Exception instance, or (status, payload) tuple
+
+    async def __aenter__(self):
+        if isinstance(self._action, BaseException):
+            raise self._action
+        status, payload = self._action
+        return _FakeResp(status, payload)
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _ScriptedSession:
+    """Serves a scripted queue of actions per URL suffix.
+
+    Each action is either an Exception instance (raised on context entry, to
+    simulate a connection/DNS failure) or a ``(status, payload)`` tuple.
+    """
+
+    def __init__(self, script: dict[str, list]):
+        self._script = {k: list(v) for k, v in script.items()}
+        self.calls: list[tuple[str, str]] = []
+
+    def _next(self, method: str, url: str):
+        self.calls.append((method, url))
+        if url.endswith("/auth/basic/app/login"):
+            return _FakeReqCtx((200, _LOGIN_PAYLOAD))
+        for suffix, actions in self._script.items():
+            if url.endswith(suffix) and actions:
+                return _FakeReqCtx(actions.pop(0))
+        raise AssertionError(f"No scripted action for {method} {url}")
+
+    def get(self, url, **kwargs):
+        return self._next("get", url)
+
+    def post(self, url, **kwargs):
+        return self._next("post", url)
+
+
+def _make_client(script):
+    session = _ScriptedSession(script)
+    client = client_mod.HomGarClient("31", "a@b.com", "pw", session, "homgar")
+    client._token = "tok"
+    client._refresh_token = "r"
+    client._token_expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
+    return client, session
+
+
+def _count(session, suffix):
+    return sum(1 for _m, url in session.calls if url.endswith(suffix))
+
+
+_LIST = "/app/member/appHome/list"
+
+
+# --- sleep patch so backoff does not actually wait -------------------------
+
+_SLEEPS: list[float] = []
+
+
+async def _fake_sleep(delay):
+    _SLEEPS.append(delay)
+
+
+async def _test_retries_503_then_succeeds():
+    _SLEEPS.clear()
+    script = {_LIST: [(503, {}), (200, {"code": 0, "data": [{"hid": 1}]})]}
+    client, session = _make_client(script)
+    result = await client.list_homes()
+    check("list_homes recovers after a 503 (returns homes)", result == [{"hid": 1}], f"got {result!r}")
+    check("list_homes retried once after 503 (2 GETs)", _count(session, _LIST) == 2, str(session.calls))
+    check("a backoff sleep happened between attempts", len(_SLEEPS) == 1, f"sleeps={_SLEEPS}")
+
+
+async def _test_retries_connection_error_then_succeeds():
+    _SLEEPS.clear()
+    import aiohttp  # the stub registered above
+    err = aiohttp.ClientConnectorError("Cannot connect to host region3.homgarus.com:443")
+    script = {_LIST: [err, (200, {"code": 0, "data": []})]}
+    client, session = _make_client(script)
+    result = await client.list_homes()
+    check("list_homes recovers after a connection error", result == [], f"got {result!r}")
+    check("list_homes retried once after connection error (2 GETs)", _count(session, _LIST) == 2, str(session.calls))
+
+
+async def _test_retries_timeout_then_succeeds():
+    _SLEEPS.clear()
+    script = {_LIST: [asyncio.TimeoutError("Connection timeout to host"), (200, {"code": 0, "data": []})]}
+    client, session = _make_client(script)
+    result = await client.list_homes()
+    check("list_homes recovers after a connection timeout", result == [], f"got {result!r}")
+    check("list_homes retried once after timeout (2 GETs)", _count(session, _LIST) == 2, str(session.calls))
+
+
+async def _test_exhausts_retries_then_raises_transient():
+    _SLEEPS.clear()
+    # More 503s than there are attempts.
+    script = {_LIST: [(503, {})] * 10}
+    client, session = _make_client(script)
+    raised = None
+    try:
+        await client.list_homes()
+    except client_mod.HomGarApiError as err:
+        raised = err
+    check("persistent 503 eventually raises", raised is not None)
+    check(
+        "raised error is a HomGarTransientError",
+        isinstance(raised, client_mod.HomGarTransientError),
+        f"got {type(raised).__name__}",
+    )
+    attempts = _count(session, _LIST)
+    check("gave up after a bounded number of attempts (2-5)", 2 <= attempts <= 5, f"attempts={attempts}")
+    check("slept once fewer than attempts (no sleep after final try)", len(_SLEEPS) == attempts - 1,
+          f"attempts={attempts} sleeps={_SLEEPS}")
+    check("backoff is non-decreasing (exponential-ish)", _SLEEPS == sorted(_SLEEPS), f"sleeps={_SLEEPS}")
+
+
+async def _test_4xx_raises_immediately_without_retry():
+    _SLEEPS.clear()
+    script = {_LIST: [(404, {})]}
+    client, session = _make_client(script)
+    raised = None
+    try:
+        await client.list_homes()
+    except client_mod.HomGarApiError as err:
+        raised = err
+    check("a 404 raises HomGarApiError", raised is not None)
+    check("a 404 is NOT treated as transient", not isinstance(raised, client_mod.HomGarTransientError),
+          f"got {type(raised).__name__}")
+    check("a 404 is not retried (1 GET)", _count(session, _LIST) == 1, str(session.calls))
+    check("a 404 does not sleep", len(_SLEEPS) == 0, f"sleeps={_SLEEPS}")
+
+
+async def _test_clean_200_never_retries():
+    _SLEEPS.clear()
+    script = {_LIST: [(200, {"code": 0, "data": [{"hid": 7}]})]}
+    client, session = _make_client(script)
+    result = await client.list_homes()
+    check("clean 200 returns immediately", result == [{"hid": 7}], f"got {result!r}")
+    check("clean 200 issues a single GET", _count(session, _LIST) == 1, str(session.calls))
+    check("clean 200 never sleeps", len(_SLEEPS) == 0, f"sleeps={_SLEEPS}")
+
+
+async def _test_control_command_does_not_retry_on_transient():
+    # An irrigation command ("start for N seconds") is absolute, not idempotent.
+    # A post-send disconnect/timeout must NOT trigger an automatic resend, which
+    # could restart/extend watering. Control endpoints fail fast instead.
+    _SLEEPS.clear()
+    _CTL = "/app/device/controlWorkMode"
+    script = {_CTL: [asyncio.TimeoutError("Connection timeout to host"), (200, {"code": 0, "data": {}})]}
+    client, session = _make_client(script)
+    raised = None
+    try:
+        await client.control_work_mode(
+            mid=1, addr=2, device_name="d", product_key="p", port=1, mode=1, duration=60,
+        )
+    except client_mod.HomGarApiError as err:
+        raised = err
+    check("control_work_mode does NOT retry a transient error", _count(session, _CTL) == 1, str(session.calls))
+    check("control_work_mode surfaces the transient failure", raised is not None)
+    check("control_work_mode did not sleep/backoff on a write", len(_SLEEPS) == 0, f"sleeps={_SLEEPS}")
+
+
+async def _test_set_device_state_does_not_retry_on_5xx():
+    _SLEEPS.clear()
+    _SET = "/app/device/setDeviceStatus"
+    script = {_SET: [(503, {}), (200, {"code": 0})]}
+    client, session = _make_client(script)
+    raised = None
+    try:
+        await client.set_device_state(
+            home_id=1, device_name="d", mid=1, product_key="p", state={"port_1": True},
+        )
+    except client_mod.HomGarApiError as err:
+        raised = err
+    check("set_device_state does NOT retry a 503 write", _count(session, _SET) == 1, str(session.calls))
+    check("set_device_state raises on the 503", raised is not None)
+
+
+def _test_backoff_constant_sane():
+    b = client_mod._TRANSIENT_RETRY_BACKOFF
+    check("backoff schedule is a non-empty tuple", isinstance(b, tuple) and len(b) >= 1, f"got {b!r}")
+    check("total backoff stays within a single poll (<30s)", sum(b) < 30, f"sum={sum(b)}")
+    check("HomGarTransientError subclasses HomGarApiError",
+          issubclass(client_mod.HomGarTransientError, client_mod.HomGarApiError))
+
+
+def main() -> int:
+    print("Transient-error retry/backoff regression tests (issue #82)")
+    _test_backoff_constant_sane()
+    original_sleep = client_mod.asyncio.sleep
+    client_mod.asyncio.sleep = _fake_sleep
+    try:
+        asyncio.run(_test_retries_503_then_succeeds())
+        asyncio.run(_test_retries_connection_error_then_succeeds())
+        asyncio.run(_test_retries_timeout_then_succeeds())
+        asyncio.run(_test_exhausts_retries_then_raises_transient())
+        asyncio.run(_test_4xx_raises_immediately_without_retry())
+        asyncio.run(_test_clean_200_never_retries())
+        asyncio.run(_test_control_command_does_not_retry_on_transient())
+        asyncio.run(_test_set_device_state_does_not_retry_on_5xx())
+    finally:
+        client_mod.asyncio.sleep = original_sleep
+    print(f"\n{PASS} passed, {FAIL} failed")
+    return 1 if FAIL else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Two independent bug fixes, shipped together as **v3.0.42**.

## #81 — HTV103FRF (single-zone valve) misparsed via Bresser gateway
A single-zone RF water timer read through a Bresser HWS388WRF-V7 gateway emits a **legacy** payload (`1,-55,1;0,124,0,0,0,0`), not the usual TLV frame. The decoder only ran valve semantics for multi-port valves (`portNumber > 1`), so single-port valves fell into the generic weather parser — producing `-16 °C` temperatures, `480%` humidity, and a "Last Session Volume" of `60.00 L` that was actually the 600-second target duration.

New `_decode_legacy_single_zone_valve()` decodes the array as `[0]` flow (÷10 L/min), `[1]` session volume (÷10 L), `[3]` start ts, `[4]` target duration → `is_watering`/`valve_state`/`flow_rate`/`last_water_volume`/`current_session_duration`/`irrigation_end_time`, and the phantom temperature/humidity entities are gone. Gated by `is_valve_model and port_number == 1` on the **legacy path only** — multi-zone valves and the TLV path are untouched. Thanks @mm060488 for the app-verified decode.

## #82 — Transient cloud timeouts / DNS / 503
The cloud intermittently returns connection/DNS timeouts and HTTP 503s that self-resolve while the app keeps working. There was **no** network/5xx retry anywhere (the `1001/1004` re-auth path needs a `200` body, so it can't cover these).

- New `_request_json()` retries transient network errors + 5xx with a short **1s/2s/4s** backoff, raising a new `HomGarTransientError` only after retries exhaust; **4xx still fail fast**. All nine authed endpoints route through it, preserving their token-reauth logic.
- **Write/control endpoints pass `retry=False`** — an absolute "run for N seconds" command is never silently re-actuated after a post-send disconnect.
- The coordinator **retains a hub's last-good status** on a failed individual fetch, **capped at `_MAX_STALE_STATUS_POLLS` (~10 min)** so a sustained outage still surfaces as Unavailable instead of showing stale "watering" state forever.

Thanks @thomasgraf99 for the detailed multi-error report.

## Tests (all in the pre-commit Docker gate)
- `tests/fixtures/payloads/HTV103FRF.json` — 3 app-verified legacy payloads (idle / watering / post-session).
- `tests/run_transient_retry_tests.py` — 27 checks: retry-then-succeed, backoff, exhaustion → `HomGarTransientError`, 4xx no-retry, clean 200 no-retry, **writes never retry**.
- `tests/run_coordinator_retention_tests.py` — 6 checks: retain on blip, still retain at threshold, blank past the cap, empty-prior stays empty.

Full run: HA integration sets up cleanly · fixture corpus 364/364 · decoder suite 84/84 · transient-retry, retention, token, and UA suites all green.

Reviewed by an independent agent pass; both raised regression-risk tradeoffs (write re-actuation, unbounded staleness) were fixed in this branch before commit.

Issues intentionally left open for post-release verification — no close keywords.