### PR TITLE
fix(sensor): use UnitOfRatio.PARTS_PER_MILLION where available (#84)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### 🐛 Bug Fixes
+- **No more `CONCENTRATION_PARTS_PER_MILLION` deprecation warning on HA 2026.8+** — Home Assistant 2026.8 deprecated `CONCENTRATION_PARTS_PER_MILLION` in favour of `UnitOfRatio.PARTS_PER_MILLION` (removal scheduled for Core 2027.8), and logged `The deprecated constant CONCENTRATION_PARTS_PER_MILLION was used from homgar` on every start. The CO2 sensor definitions now use the enum. Note the fix is **not** a straight swap: `UnitOfRatio` was only added in Core **2026.7**, so an unconditional import would raise `ImportError` and break setup outright on every core below that — a far worse failure than the log line. `sensor_defs.py` therefore imports the enum where it exists and falls back to the legacy constant otherwise, covering all three regimes in the wild (≤2026.6 no enum, 2026.7 enum but no deprecation, ≥2026.8 deprecation). Both resolve to `"ppm"`, so CO2 entity state and history are unchanged. Thanks to [@thomasgraf99](https://github.com/thomasgraf99) for the report. ([#84](https://github.com/brettmeyerowitz/homeassistant-homgar/issues/84))
+
+### 🧪 Tests
+- `tests/run_ppm_unit_tests.py` (11 checks) — pins both import branches by injecting and removing `UnitOfRatio` on `homeassistant.const` and reloading the module: the modern path resolves to the enum member and emits no deprecation warning, the legacy path falls back without `ImportError`, and both CO2 sensor defs stay `"ppm"` either way. Wired into the pre-commit Docker gate.
+
+---
+
 ## [3.0.42] - 2026-08-04
 
 ### 🐛 Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [3.0.43] - 2026-08-09
 
 ### 🐛 Bug Fixes
 - **No more `CONCENTRATION_PARTS_PER_MILLION` deprecation warning on HA 2026.8+** — Home Assistant 2026.8 deprecated `CONCENTRATION_PARTS_PER_MILLION` in favour of `UnitOfRatio.PARTS_PER_MILLION` (removal scheduled for Core 2027.8), and logged `The deprecated constant CONCENTRATION_PARTS_PER_MILLION was used from homgar` on every start. The CO2 sensor definitions now use the enum. Note the fix is **not** a straight swap: `UnitOfRatio` was only added in Core **2026.7**, so an unconditional import would raise `ImportError` and break setup outright on every core below that — a far worse failure than the log line. `sensor_defs.py` therefore imports the enum where it exists and falls back to the legacy constant otherwise, covering all three regimes in the wild (≤2026.6 no enum, 2026.7 enum but no deprecation, ≥2026.8 deprecation). Both resolve to `"ppm"`, so CO2 entity state and history are unchanged. Thanks to [@thomasgraf99](https://github.com/thomasgraf99) for the report. ([#84](https://github.com/brettmeyerowitz/homeassistant-homgar/issues/84))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [3.0.43] - 2026-08-09
+## [Unreleased] - 3.0.43
 
 ### 🐛 Bug Fixes
 - **No more `CONCENTRATION_PARTS_PER_MILLION` deprecation warning on HA 2026.8+** — Home Assistant 2026.8 deprecated `CONCENTRATION_PARTS_PER_MILLION` in favour of `UnitOfRatio.PARTS_PER_MILLION` (removal scheduled for Core 2027.8), and logged `The deprecated constant CONCENTRATION_PARTS_PER_MILLION was used from homgar` on every start. The CO2 sensor definitions now use the enum. Note the fix is **not** a straight swap: `UnitOfRatio` was only added in Core **2026.7**, so an unconditional import would raise `ImportError` and break setup outright on every core below that — a far worse failure than the log line. `sensor_defs.py` therefore imports the enum where it exists and falls back to the legacy constant otherwise, covering all three regimes in the wild (≤2026.6 no enum, 2026.7 enum but no deprecation, ≥2026.8 deprecation). Both resolve to `"ppm"`, so CO2 entity state and history are unchanged. Thanks to [@thomasgraf99](https://github.com/thomasgraf99) for the report. ([#84](https://github.com/brettmeyerowitz/homeassistant-homgar/issues/84))

--- a/custom_components/homgar/manifest.json
+++ b/custom_components/homgar/manifest.json
@@ -13,5 +13,5 @@
         "custom_components.homgar"
     ],
     "requirements": ["paho-mqtt>=1.6.0"],
-    "version": "3.0.42"
+    "version": "3.0.43"
 }

--- a/custom_components/homgar/sensor_defs.py
+++ b/custom_components/homgar/sensor_defs.py
@@ -21,7 +21,6 @@ from homeassistant.const import (
     UnitOfTemperature,
     UnitOfElectricPotential,
     PERCENTAGE,
-    CONCENTRATION_PARTS_PER_MILLION,
     LIGHT_LUX,
     UnitOfPressure,
     UnitOfVolume,
@@ -30,6 +29,25 @@ from homeassistant.const import (
     UnitOfTime,
     UnitOfSpeed,
 )
+
+# ppm unit constant across three live HA regimes (see issue #84):
+#   <= 2026.6  UnitOfRatio does not exist anywhere in homeassistant; the legacy
+#              constant is a plain Final and emits no warning.
+#      2026.7  UnitOfRatio added; CONCENTRATION_PARTS_PER_MILLION rebased onto
+#              it but still live and silent.
+#   >= 2026.8  CONCENTRATION_PARTS_PER_MILLION deprecated, removal in Core
+#              2027.8. This is where the reported warning comes from.
+# Import the enum where it exists and fall back otherwise — an unconditional
+# import would break setup on every core below 2026.7, which is a far worse
+# failure than the log line it fixes. Both resolve to "ppm", so entity state is
+# identical either way. Once the supported floor reaches 2026.7 this guard can
+# be dropped for a direct import; the legacy constant survives until 2027.8.
+try:  # HA >= 2026.7
+    from homeassistant.const import UnitOfRatio
+
+    PPM = UnitOfRatio.PARTS_PER_MILLION
+except ImportError:  # pragma: no cover - exercised on HA < 2026.7
+    from homeassistant.const import CONCENTRATION_PARTS_PER_MILLION as PPM
 
 
 @dataclass
@@ -64,11 +82,11 @@ FIELD_SENSOR_MAP: dict[str, SensorDef | None] = {
     ),
     "carbon_dioxide": SensorDef(
         device_class=SensorDeviceClass.CO2,
-        unit=CONCENTRATION_PARTS_PER_MILLION,
+        unit=PPM,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     "carbon_dioxide_warning_threshold": SensorDef(
-        unit=CONCENTRATION_PARTS_PER_MILLION,
+        unit=PPM,
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:molecule-co2",
         name="CO2 Warning Threshold",

--- a/scripts/pre-commit-docker-test.sh
+++ b/scripts/pre-commit-docker-test.sh
@@ -339,6 +339,16 @@ else
     exit 1
 fi
 
+# ── Test: ppm unit constant (issue #84) ───────────────────────────────────
+echo "🧪 Running ppm unit constant tests..."
+docker cp tests/run_ppm_unit_tests.py ha-test:/tmp/tests/run_ppm_unit_tests.py > /dev/null
+if docker exec ha-test python3 /tmp/tests/run_ppm_unit_tests.py; then
+    echo "✅ ppm unit constant tests passed"
+else
+    echo "❌ ERROR: ppm unit constant tests failed"
+    exit 1
+fi
+
 # ── Test: decoder regression suite (scripts/test_decoders.py) ─────────────
 echo "🧪 Running decoder regression suite..."
 docker cp scripts/test_decoders.py ha-test:/tmp/test_decoders.py > /dev/null

--- a/tests/run_ppm_unit_tests.py
+++ b/tests/run_ppm_unit_tests.py
@@ -1,0 +1,104 @@
+"""ppm unit-constant tests (issue #84). Runs in the ha-test container against
+the deployed integration at /config (imports Home Assistant).
+
+HA 2026.7 added UnitOfRatio; 2026.8 then deprecated
+CONCENTRATION_PARTS_PER_MILLION (removal in Core 2027.8). Cores at or below
+2026.6 do not ship UnitOfRatio at all, so sensor_defs.py imports the enum when
+present and falls back to the legacy constant otherwise. These tests pin both
+branches so neither regresses.
+"""
+import enum
+import importlib
+import sys
+import warnings
+
+sys.path.insert(0, "/config")
+
+import homeassistant.const as ha_const  # noqa: E402
+
+PASS = 0
+FAIL = 0
+
+
+def check(name, cond, detail=""):
+    global PASS, FAIL
+    if cond:
+        print(f"  ✅ {name}"); PASS += 1
+    else:
+        print(f"  ❌ {name}{': ' + detail if detail else ''}"); FAIL += 1
+
+
+def reload_sensor_defs():
+    """Re-import sensor_defs so its module-level try/except runs again."""
+    sys.modules.pop("custom_components.homgar.sensor_defs", None)
+    return importlib.import_module("custom_components.homgar.sensor_defs")
+
+
+class _FakeUnitOfRatio(enum.StrEnum):
+    """Stand-in for HA 2026.7+ UnitOfRatio, so the modern branch is testable
+    on any core version."""
+
+    PARTS_PER_MILLION = "ppm"
+    PARTS_PER_BILLION = "ppb"
+    PERCENTAGE = "%"
+
+
+print(f"HA {ha_const.__version__} (native UnitOfRatio: {hasattr(ha_const, 'UnitOfRatio')})")
+
+# ── As deployed on this core ───────────────────────────────────────────────
+print("\nAs deployed on this core:")
+sd = reload_sensor_defs()
+check("module imports without error", sd is not None)
+check("PPM resolves to 'ppm'", sd.PPM == "ppm", f"got {sd.PPM!r}")
+check("carbon_dioxide unit is ppm",
+      sd.FIELD_SENSOR_MAP["carbon_dioxide"].unit == "ppm",
+      f"got {sd.FIELD_SENSOR_MAP['carbon_dioxide'].unit!r}")
+check("carbon_dioxide_warning_threshold unit is ppm",
+      sd.FIELD_SENSOR_MAP["carbon_dioxide_warning_threshold"].unit == "ppm",
+      f"got {sd.FIELD_SENSOR_MAP['carbon_dioxide_warning_threshold'].unit!r}")
+
+# ── HA >= 2026.7: UnitOfRatio present ──────────────────────────────────────
+print("\nHA >= 2026.7 (UnitOfRatio present):")
+had_native = hasattr(ha_const, "UnitOfRatio")
+native = getattr(ha_const, "UnitOfRatio", None)
+ha_const.UnitOfRatio = native if had_native else _FakeUnitOfRatio
+try:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        sd = reload_sensor_defs()
+    check("prefers UnitOfRatio.PARTS_PER_MILLION",
+          sd.PPM is ha_const.UnitOfRatio.PARTS_PER_MILLION, f"got {sd.PPM!r}")
+    check("still equals 'ppm'", sd.PPM == "ppm", f"got {sd.PPM!r}")
+    check("no deprecation warning raised",
+          not [w for w in caught if "CONCENTRATION_PARTS_PER_MILLION" in str(w.message)],
+          f"got {[str(w.message) for w in caught]}")
+    check("CO2 sensors use the enum",
+          sd.FIELD_SENSOR_MAP["carbon_dioxide"].unit
+          is ha_const.UnitOfRatio.PARTS_PER_MILLION)
+finally:
+    if had_native:
+        ha_const.UnitOfRatio = native
+    else:
+        del ha_const.UnitOfRatio
+
+# ── HA < 2026.7: UnitOfRatio absent ────────────────────────────────────────
+print("\nHA < 2026.7 (UnitOfRatio absent):")
+removed = None
+if hasattr(ha_const, "UnitOfRatio"):
+    removed = ha_const.UnitOfRatio
+    del ha_const.UnitOfRatio
+try:
+    sd = reload_sensor_defs()
+    check("falls back without ImportError", sd is not None)
+    check("fallback still yields 'ppm'", sd.PPM == "ppm", f"got {sd.PPM!r}")
+    check("CO2 sensors still ppm",
+          sd.FIELD_SENSOR_MAP["carbon_dioxide"].unit == "ppm")
+finally:
+    if removed is not None:
+        ha_const.UnitOfRatio = removed
+
+# Leave the module cache holding the real, unpatched import.
+reload_sensor_defs()
+
+print(f"\n{PASS} passed, {FAIL} failed")
+sys.exit(1 if FAIL else 0)


### PR DESCRIPTION
Fixes the `CONCENTRATION_PARTS_PER_MILLION` deprecation warning reported in #84, without breaking older cores.

## The catch

The suggested fix in the issue — importing `UnitOfRatio` directly — is **not backwards compatible**. `UnitOfRatio` was only added in Core **2026.7**; before that it does not exist anywhere in the `homeassistant` package. An unconditional import raises `ImportError` and breaks integration setup outright on older cores, which is a far worse failure than the log line it fixes.

Verified against a local **2026.6.4** container:

```
naive fix would FAIL at import: cannot import name 'UnitOfRatio' from 'homeassistant.const'
```

There are three regimes live in the wild right now:

| Core | `UnitOfRatio` | `CONCENTRATION_PARTS_PER_MILLION` |
|---|---|---|
| ≤ 2026.6 | absent | plain `Final`, silent |
| 2026.7 | added | rebased onto the enum, still silent |
| ≥ 2026.8 | present | **deprecated**, removal in 2027.8 |

Note the deprecation landed in 2026.8, not 2026.7 — the enum and the warning arrived one release apart. No single unconditional import covers all three.

## Change

`sensor_defs.py` imports the enum where it exists and falls back to the legacy constant otherwise, exporting a single `PPM` used by both CO2 sensor defs. Both resolve to `"ppm"`, so CO2 entity state and history are unchanged, and no `hacs.json` minimum-version bump is needed. The guard can be dropped for a direct import once the supported floor reaches 2026.7; the legacy constant survives until 2027.8.

## Tests

`tests/run_ppm_unit_tests.py` (11 checks) pins both branches by injecting and removing `UnitOfRatio` on `homeassistant.const` and reloading the module:

- modern path resolves to the enum member and emits no deprecation warning
- legacy path falls back without `ImportError`
- both CO2 sensor defs stay `"ppm"` either way

Wired into the pre-commit Docker gate. Full gate green on 2026.6.4, integration set up cleanly with zero deprecation or traceback lines in `home-assistant.log`.

**Caveat:** the ≥2026.7 branch is exercised with an injected stand-in enum, not a genuine 2026.7+ core — that covers the import logic but not HA's own deprecation machinery firing for real.

## Release

Versioned as **3.0.43** in `manifest.json`. The changelog section is deliberately left as `## [Unreleased] - 3.0.43` — no release is being cut now, so the date gets stamped when 3.0.43 actually ships. No tag has been created and nothing has been pushed to `main`.
