### PR TITLE
fix(coordinator): retain last-good home names on a transient list_homes failure (#82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### 🐛 Bug Fixes
+- **A transient cloud blip no longer blanks home names or logs the same failure twice** — follow-up to the v3.0.42 work on [#82](https://github.com/brettmeyerowitz/homeassistant-homgar/issues/82). v3.0.42 added transient retry and last-good retention for per-hub *status*, but the `hid → homeName` map was still rebuilt from scratch every cycle and left **empty** when `list_homes` failed. That is not cosmetic: `homeName` falls back to `""` and `areas.py` skips area seeding entirely for a blank name, so a passing blip could quietly suppress it. The coordinator now retains the last-good map. Home names are effectively static, so unlike hub status this needs no staleness cap — a stale name cannot mask an outage the way a stuck "watering" state would. Separately, one failure used to produce **two** WARNING entries for the same event (the client's "failed after N attempts" plus the coordinator's "could not fetch home names"); the coordinator line now drops to debug whenever a cached map covers the failure, and warns only when there is genuinely no map to fall back on. Thanks to [@thomasgraf99](https://github.com/thomasgraf99) for the interim report with the paired log excerpts.
+
+### 🧪 Tests
+- `tests/run_home_name_retention_tests.py` (8 checks) — retention returns the cached map on failure and a *copy* of it (so a later cycle cannot mutate the retained one), falls back to an empty map when nothing is cached, and the warn/debug predicate stays quiet only when a cache actually covers the blip. Wired into the pre-commit Docker gate.
+
+---
+
 ## [3.0.42] - 2026-08-04
 
 ### 🐛 Bug Fixes

--- a/custom_components/homgar/coordinator.py
+++ b/custom_components/homgar/coordinator.py
@@ -116,6 +116,34 @@ def _status_on_fetch_failure(
     return {"subDeviceStatus": []}
 
 
+def _home_names_on_fetch_failure(cached: dict[int, str] | None) -> dict[int, str]:
+    """Choose the hid -> homeName map to use when list_homes failed this poll.
+
+    The map was previously rebuilt from scratch each cycle and left empty on
+    failure. That is not harmless: ``hub_copy["homeName"]`` falls back to ``""``
+    and areas.py skips area seeding entirely for a blank name, so a passing
+    cloud blip could quietly suppress it. Retain the last-good map instead.
+
+    Unlike hub status, this needs no staleness cap — a home's name is
+    effectively static, so a stale one carries no risk of masking an outage the
+    way a stuck "watering" state would. Returns a copy so a later cycle cannot
+    mutate the retained map. See issue #82.
+    """
+    return dict(cached) if cached else {}
+
+
+def _should_warn_home_name_failure(cached: dict[int, str] | None) -> bool:
+    """Whether a failed list_homes fetch deserves a WARNING.
+
+    The client already logs one warning when its retries are exhausted, so
+    logging again here made a single blip produce two WARNING entries for the
+    same event (reported on issue #82). When a cached map covers the failure
+    nothing user-visible degraded, so this drops to debug; a warning is kept
+    only when there is genuinely no map to fall back on.
+    """
+    return not cached
+
+
 def _hub_identity_keys(hub: dict) -> set[tuple[str, str]]:
     """Return stable cloud identity keys that can reveal duplicate hub rows."""
     keys: set[tuple[str, str]] = set()
@@ -142,6 +170,9 @@ class HomGarCoordinator(DataUpdateCoordinator):
         self._notified_unknown_models: set[str] = set()
         self._mqtt_diagnostics: dict[str, dict] = {}
         self._last_good_data: dict[str, dict] = {}
+        # Last successful hid -> homeName map, reused when list_homes fails so a
+        # blip does not blank home names. See _home_names_on_fetch_failure.
+        self._last_good_home_names: dict[int, str] = {}
         # Consecutive failed status fetches per hub mid, used to cap how long a
         # hub may coast on retained last-good status. See _status_on_fetch_failure.
         self._status_miss_count: dict[int, int] = {}
@@ -167,8 +198,22 @@ class HomGarCoordinator(DataUpdateCoordinator):
                     name_val = h.get("homeName") or h.get("name") or ""
                     if hid_val:
                         home_name_by_hid[int(hid_val)] = name_val
+                if home_name_by_hid:
+                    self._last_good_home_names = dict(home_name_by_hid)
             except Exception as ex:  # noqa: BLE001
-                _LOGGER.warning("HomGar: could not fetch home names: %s", ex)
+                # Retain the last-good map rather than blanking home names for
+                # the cycle, and stay quiet when it covers the blip — the client
+                # has already logged its exhausted retries. See issue #82.
+                home_name_by_hid = _home_names_on_fetch_failure(
+                    self._last_good_home_names
+                )
+                if _should_warn_home_name_failure(self._last_good_home_names):
+                    _LOGGER.warning("HomGar: could not fetch home names: %s", ex)
+                else:
+                    _LOGGER.debug(
+                        "HomGar: could not fetch home names (%s); retaining %d cached name(s)",
+                        ex, len(home_name_by_hid),
+                    )
 
             for hid in homes:
                 devices = await self._client.get_devices_by_hid(hid)

--- a/scripts/pre-commit-docker-test.sh
+++ b/scripts/pre-commit-docker-test.sh
@@ -339,6 +339,16 @@ else
     exit 1
 fi
 
+# ── Test: home-name retention (issue #82 follow-up) ───────────────────────
+echo "🧪 Running home-name retention tests..."
+docker cp tests/run_home_name_retention_tests.py ha-test:/tmp/tests/run_home_name_retention_tests.py > /dev/null
+if docker exec ha-test python3 /tmp/tests/run_home_name_retention_tests.py; then
+    echo "✅ Home-name retention tests passed"
+else
+    echo "❌ ERROR: Home-name retention tests failed"
+    exit 1
+fi
+
 # ── Test: decoder regression suite (scripts/test_decoders.py) ─────────────
 echo "🧪 Running decoder regression suite..."
 docker cp scripts/test_decoders.py ha-test:/tmp/test_decoders.py > /dev/null

--- a/tests/run_home_name_retention_tests.py
+++ b/tests/run_home_name_retention_tests.py
@@ -1,0 +1,91 @@
+"""Regression test: the coordinator retains last-good home names when the
+list_homes fetch fails, and logs the failure quietly when it does.
+
+Issue #82 follow-up. v3.0.42 added transient retry and last-good retention for
+per-hub *status*, but the home-name map was still rebuilt from scratch every
+cycle and left empty when list_homes failed. Reported on 2026-08-08: a single
+connection timeout produced two WARNING entries for one event — one from the
+client ("failed after 4 attempts") and one from the coordinator ("could not
+fetch home names") — even though the cycle carried on and entities were fine.
+
+An empty map is not harmless: hub_copy["homeName"] falls back to "", and
+areas.py skips area seeding entirely for a blank name. Retaining the previous
+map keeps that working through a blip. Home names are effectively static, so
+stale ones carry no risk — unlike stale status, this needs no staleness cap.
+
+Runs in the ha-test container against the deployed integration at /config.
+"""
+import sys
+
+sys.path.insert(0, "/config")
+
+from custom_components.homgar.coordinator import (  # noqa: E402
+    _home_names_on_fetch_failure,
+    _should_warn_home_name_failure,
+)
+
+PASS = 0
+FAIL = 0
+
+
+def check(name, cond, detail=""):
+    global PASS, FAIL
+    if cond:
+        print(f"  ✅ {name}"); PASS += 1
+    else:
+        print(f"  ❌ {name}{': ' + detail if detail else ''}"); FAIL += 1
+
+
+cached = {123: "Garden", 456: "Front Yard"}
+
+# A blip after at least one good poll must keep the names, so hubs keep their
+# homeName and area seeding keeps working.
+check(
+    "retains cached home names on failure",
+    _home_names_on_fetch_failure(cached) == cached,
+    f"got {_home_names_on_fetch_failure(cached)!r}",
+)
+check(
+    "retains indefinitely — no staleness cap for static names",
+    _home_names_on_fetch_failure(cached) == cached,
+)
+
+# The returned map must not alias the cache, or a later cycle mutating its
+# result would corrupt the retained copy.
+returned = _home_names_on_fetch_failure(cached)
+returned[789] = "Injected"
+check(
+    "returns a copy, not the cached dict itself",
+    cached == {123: "Garden", 456: "Front Yard"},
+    f"cache was mutated: {cached!r}",
+)
+
+# No cache yet (first poll ever failed) -> empty map, not a crash.
+check(
+    "falls back to an empty map when nothing is cached",
+    _home_names_on_fetch_failure(None) == {},
+    f"got {_home_names_on_fetch_failure(None)!r}",
+)
+check(
+    "an empty cache stays empty",
+    _home_names_on_fetch_failure({}) == {},
+    f"got {_home_names_on_fetch_failure({})!r}",
+)
+
+# Log level: quiet when nothing user-visible degraded, loud when names really
+# are unavailable. This is what removes the duplicate WARNING pair.
+check(
+    "does not warn when a cached map covers the failure",
+    _should_warn_home_name_failure(cached) is False,
+)
+check(
+    "warns when there is no cache to fall back on",
+    _should_warn_home_name_failure(None) is True,
+)
+check(
+    "warns when the cache is empty",
+    _should_warn_home_name_failure({}) is True,
+)
+
+print(f"\n{PASS} passed, {FAIL} failed")
+sys.exit(1 if FAIL else 0)


### PR DESCRIPTION
Follow-up to the v3.0.42 transient-retry work on #82, prompted by an interim report on that issue.

## What the report showed

On 2026-08-08 18:03:16 CEST a connection timeout to `appHome/list` exhausted all 4 attempts. The retry path worked exactly as designed — the outage was simply longer than the 1s/2s/4s window. But it exposed two rough edges.

**Timing check:** `_REQUEST_TIMEOUT` uses `connect=10`, and "Connection timeout to host" is the connect timeout, so 4 attempts ≈ 40s plus 7s of backoff ≈ **47s worst case** — comfortably inside the 120s poll. The retry window isn't crowding the next cycle, so the backoff is deliberately left unchanged; the next poll is the right retry.

## Changes

**1. Home names are now retained.** v3.0.42 added last-good retention for per-hub *status*, but the `hid → homeName` map was still rebuilt from scratch each cycle and left empty on failure. Not cosmetic: `hub_copy["homeName"]` falls back to `""` and `areas.py:70-71` skips area seeding entirely for a blank name, so a passing blip could quietly suppress it.

Unlike hub status this needs **no staleness cap** — a home's name is effectively static, so a stale one cannot mask an outage the way a stuck "watering" state would. The helper returns a copy so a later cycle cannot mutate the retained map.

**2. No more duplicate WARNING pair.** One failure produced two entries for the same event — the client's `list_homes failed after 4 attempts` and the coordinator's `could not fetch home names`. The coordinator line now drops to debug whenever a cached map covers the failure, and warns only when there is genuinely no map to fall back on.

The client's warning is **deliberately left alone**: several callers swallow the raised error, so it is the only visible signal on those paths. Demoting it would have traded duplicate logging for silent failures.

## Not a bug: entities were never at risk

Worth recording, since the reporter couldn't observe it at the time. That event could not have made entities Unavailable — `list_homes` is caught non-fatally at `coordinator.py:163-171` and the cycle continues to `get_devices_by_hid` and status decoding, which are what raise `UpdateFailed`. His log shows no such error.

## Tests

`tests/run_home_name_retention_tests.py` (8 checks): retention on failure, the defensive copy, the no-cache fallback, an empty cache staying empty, and the warn/debug predicate in all three states. Wired into the pre-commit Docker gate. Full gate green.

No version bump — the changelog entry sits under `## [Unreleased]`.
