### PR TITLE
fix(api): retry write commands on provably pre-send failures (#82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### 🐛 Bug Fixes
+- **A valve command that never reached the cloud now retries itself instead of failing in your face** — follow-up to [#82](https://github.com/brettmeyerowitz/homeassistant-homgar/issues/82). Write commands (`controlWorkMode`, `controlWorkModeDP`, `setDeviceStatus`) were given a blanket no-retry policy in v3.0.42, deliberately: "run for N seconds" is absolute, not idempotent, so resending it after the cloud already accepted it could re-actuate irrigation. The cost showed up in a live report — manually opening a valve failed outright with `controlWorkMode: Connection timeout to host`, and an immediate manual retry succeeded. That particular failure never needed to fail: aiohttp raises it when the TCP connect times out, **before any request bytes are sent**, so the cloud provably never saw the command and a resend cannot double-actuate. Writes now get one short resend for exactly those provably pre-send failures (connect timeout, DNS/refused connect) and continue to fail fast on everything ambiguous — read timeouts, server disconnects, and 5xx, all of which may have been delivered. The no-double-actuation guarantee is unchanged. Also fixed: the "failed after N attempts" log line reported the attempt ceiling rather than the attempts actually made, so a fail-fast write claimed more tries than it had. Thanks to [@thomasgraf99](https://github.com/thomasgraf99) for the live valve-control report.
+
+### 🧪 Tests
+- `tests/run_write_presend_retry_tests.py` (22 checks) — pins the pre-send classifier against aiohttp's real exception hierarchy, including the two traps that would silently re-admit unsafe retries: `ClientConnectorError` subclasses `ClientOSError` (which also covers mid-flight errors), and `ConnectionTimeoutError` and `SocketTimeoutError` share `ServerTimeoutError` as a base. Also covers the write path end to end: a connect timeout retries once and succeeds, a read timeout/disconnect/503 is never retried, and a persistent connect timeout stops after two attempts. Wired into the pre-commit Docker gate.
+
+---
+
 ## [3.0.42] - 2026-08-04
 
 ### 🐛 Bug Fixes

--- a/custom_components/homgar/api/client.py
+++ b/custom_components/homgar/api/client.py
@@ -40,6 +40,45 @@ _TRANSIENT_RETRY_BACKOFF = (1, 2, 4)  # seconds between attempts (3 retries)
 # and server timeouts subclass asyncio.TimeoutError.
 _TRANSIENT_NETWORK_ERRORS = (aiohttp.ClientError, asyncio.TimeoutError)
 
+# Write commands get one short resend, and only for provably pre-send failures.
+# A user is waiting on a button press, so this stays deliberately small. See
+# _is_pre_send_error and issue #82.
+_WRITE_PRE_SEND_RETRY_BACKOFF = (1,)
+
+# Failures that prove the request never left the client, so resending a
+# non-idempotent write cannot double-actuate:
+#   * ConnectionTimeoutError — aiohttp raises this when connector.connect()
+#     times out, before any request bytes are written.
+#   * ClientConnectorError — DNS failure or refused/unreachable TCP connect.
+# Deliberately narrow. Two nearby classes must NOT be included:
+#   * SocketTimeoutError shares ServerTimeoutError as a base but fires while
+#     reading the response, i.e. after the request was sent.
+#   * ClientOSError is ClientConnectorError's own base and also covers
+#     mid-flight socket errors, so matching on it would admit post-send cases.
+# ConnectionTimeoutError arrived in aiohttp 3.10; on older versions a connect
+# timeout is a plain ServerTimeoutError, indistinguishable from a read timeout,
+# so we fall back to the connector-error case only — fewer retries, never an
+# unsafe one.
+# Both names are resolved defensively: an absent one simply drops out of the
+# tuple, which costs a retry opportunity but can never make an unsafe one. An
+# empty tuple degrades cleanly to the old fail-fast-on-everything behaviour.
+_PRE_SEND_ERRORS = tuple(
+    err for err in (
+        getattr(aiohttp, "ConnectionTimeoutError", None),
+        getattr(aiohttp, "ClientConnectorError", None),
+    ) if isinstance(err, type) and issubclass(err, BaseException)
+)
+
+
+def _is_pre_send_error(err: BaseException) -> bool:
+    """Whether ``err`` proves the request never reached the server.
+
+    Used to decide if a non-idempotent write may be safely resent. Anything
+    ambiguous must answer False: failing a valve command is recoverable by the
+    user, re-actuating irrigation behind their back is not.
+    """
+    return isinstance(err, _PRE_SEND_ERRORS)
+
 
 class HomGarApiError(Exception):
     pass
@@ -122,17 +161,26 @@ class HomGarClient:
         ``retry`` is false for write/control endpoints (valve open/close, set
         state): those commands are absolute ("run for N seconds"), not
         idempotent, so a post-send disconnect must NOT auto-resend and risk
-        re-actuating irrigation. They fail fast; a transient failure still
-        raises ``HomGarTransientError`` immediately.
+        re-actuating irrigation.
+
+        Those endpoints are not entirely un-retried, though. A failure that
+        proves the request never left the client (see ``_is_pre_send_error``)
+        cannot have actuated anything, so it gets one short resend from
+        ``_WRITE_PRE_SEND_RETRY_BACKOFF`` — that turns a connect timeout from a
+        dead valve command the user must repeat by hand into a self-healing
+        one, with the no-double-actuation guarantee intact. Every ambiguous
+        failure (read timeout, disconnect, 5xx) still fails fast.
 
         Any other non-200 (e.g. 4xx) raises ``HomGarApiError`` immediately and is
         never retried. This centralises the timeout + retry policy; callers keep
         their own ``code``/token-reauth handling on the returned dict.
         """
         opener = self._get if method == "get" else self._post
-        attempts = len(_TRANSIENT_RETRY_BACKOFF) + 1 if retry else 1
+        backoff = _TRANSIENT_RETRY_BACKOFF if retry else _WRITE_PRE_SEND_RETRY_BACKOFF
+        attempts = len(backoff) + 1
         last_error: HomGarTransientError | None = None
         for attempt in range(attempts):
+            pre_send = False
             try:
                 async with opener(url, **kwargs) as resp:
                     if resp.status >= 500:
@@ -141,17 +189,25 @@ class HomGarClient:
                         raise HomGarApiError(f"{what} HTTP {resp.status}")
                     return await resp.json()
             except _TRANSIENT_NETWORK_ERRORS as err:
+                pre_send = _is_pre_send_error(err)
                 last_error = HomGarTransientError(f"{what}: {err}")
             except HomGarTransientError as err:
+                # A 5xx means the request was delivered and answered, so it is
+                # never pre-send.
                 last_error = err
+            made = attempt + 1
+            if not retry and not pre_send:
+                break
             if attempt + 1 < attempts:
-                delay = _TRANSIENT_RETRY_BACKOFF[attempt]
+                delay = backoff[attempt]
                 _LOGGER.debug(
                     "%s transient failure (attempt %d/%d), retrying in %ss: %s",
                     what, attempt + 1, attempts, delay, last_error,
                 )
                 await asyncio.sleep(delay)
-        _LOGGER.warning("%s failed after %d attempts: %s", what, attempts, last_error)
+        # Report attempts actually made, not the ceiling — a write that failed
+        # fast on an ambiguous error made one, not len(backoff) + 1.
+        _LOGGER.warning("%s failed after %d attempts: %s", what, made, last_error)
         raise last_error
 
     # --- token state helpers ---

--- a/scripts/pre-commit-docker-test.sh
+++ b/scripts/pre-commit-docker-test.sh
@@ -339,6 +339,16 @@ else
     exit 1
 fi
 
+# ── Test: write-path pre-send retry (issue #82 follow-up) ─────────────────
+echo "🧪 Running write-path pre-send retry tests..."
+docker cp tests/run_write_presend_retry_tests.py ha-test:/tmp/tests/run_write_presend_retry_tests.py > /dev/null
+if docker exec ha-test python3 /tmp/tests/run_write_presend_retry_tests.py; then
+    echo "✅ Write-path pre-send retry tests passed"
+else
+    echo "❌ ERROR: Write-path pre-send retry tests failed"
+    exit 1
+fi
+
 # ── Test: decoder regression suite (scripts/test_decoders.py) ─────────────
 echo "🧪 Running decoder regression suite..."
 docker cp scripts/test_decoders.py ha-test:/tmp/test_decoders.py > /dev/null

--- a/tests/run_write_presend_retry_tests.py
+++ b/tests/run_write_presend_retry_tests.py
@@ -1,0 +1,349 @@
+"""Regression tests: write/control commands retry ONLY provably pre-send failures.
+
+Issue #82 follow-up. Write endpoints (controlWorkMode, controlWorkModeDP,
+setDeviceStatus) are absolute, not idempotent — "run for N seconds" resent after
+the cloud already accepted it can re-actuate irrigation — so they were given a
+blanket ``retry=False``. A live report on 2026-08-10 showed the cost: opening a
+valve failed outright with
+
+    controlWorkMode: Connection timeout to host .../app/device/controlWorkMode
+
+and an immediate manual retry succeeded.
+
+That particular failure did not need to fail. aiohttp raises it from
+``_connect_and_send_request`` when ``connector.connect()`` times out — before any
+request bytes leave the client — so the cloud provably never saw the command and
+a resend cannot double-actuate. The same holds for DNS/refused connect errors.
+
+So writes now retry exactly the connect-phase failures and nothing else. The
+distinction is subtle in aiohttp's hierarchy and easy to get wrong:
+
+  * ClientConnectorError subclasses ClientOSError, so a broad ClientOSError
+    check would wrongly admit mid-flight socket errors.
+  * ConnectionTimeoutError AND SocketTimeoutError both subclass
+    ServerTimeoutError, so a broad ServerTimeoutError check would wrongly admit
+    read timeouts, which happen after the request was sent.
+
+These tests pin both traps. Reads are unaffected — they already retry everything
+transient. Runs on the host and in the ha-test container, stdlib only.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+import types
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+
+def _find_repo_root() -> Path:
+    candidates = [Path(__file__).resolve().parent, Path.cwd(), Path("/config")]
+    for start in candidates:
+        current = start
+        while True:
+            if (current / "custom_components" / "homgar" / "api" / "client.py").exists():
+                return current
+            if current.parent == current:
+                break
+            current = current.parent
+    raise RuntimeError("Could not locate repository root containing custom_components/homgar")
+
+
+ROOT = _find_repo_root()
+
+
+def _load_module(module_name: str, relative_path: str):
+    path = ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load module from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# --- aiohttp stub mirroring the real exception hierarchy --------------------
+# The MROs below are copied from aiohttp 3.13; the subclass relationships are
+# the whole point of these tests, so they must not be simplified.
+
+
+class _ClientTimeout:
+    def __init__(self, total=None, connect=None, sock_connect=None, sock_read=None):
+        self.total = total
+        self.connect = connect
+
+
+_aiohttp_stub = types.ModuleType("aiohttp")
+_aiohttp_stub.ClientTimeout = _ClientTimeout
+_aiohttp_stub.ClientSession = type("ClientSession", (), {})
+_aiohttp_stub.ClientError = type("ClientError", (Exception,), {})
+_aiohttp_stub.ClientConnectionError = type(
+    "ClientConnectionError", (_aiohttp_stub.ClientError,), {})
+# ClientOSError -> ClientConnectionError; ClientConnectorError -> ClientOSError.
+_aiohttp_stub.ClientOSError = type(
+    "ClientOSError", (_aiohttp_stub.ClientConnectionError, OSError), {})
+_aiohttp_stub.ClientConnectorError = type(
+    "ClientConnectorError", (_aiohttp_stub.ClientOSError,), {})
+# ServerConnectionError -> ClientConnectionError; both timeout flavours subclass
+# ServerTimeoutError, which also subclasses asyncio.TimeoutError.
+_aiohttp_stub.ServerConnectionError = type(
+    "ServerConnectionError", (_aiohttp_stub.ClientConnectionError,), {})
+_aiohttp_stub.ServerDisconnectedError = type(
+    "ServerDisconnectedError", (_aiohttp_stub.ServerConnectionError,), {})
+_aiohttp_stub.ServerTimeoutError = type(
+    "ServerTimeoutError", (_aiohttp_stub.ServerConnectionError, asyncio.TimeoutError), {})
+_aiohttp_stub.ConnectionTimeoutError = type(
+    "ConnectionTimeoutError", (_aiohttp_stub.ServerTimeoutError,), {})
+_aiohttp_stub.SocketTimeoutError = type(
+    "SocketTimeoutError", (_aiohttp_stub.ServerTimeoutError,), {})
+sys.modules["aiohttp"] = _aiohttp_stub
+
+sys.modules.setdefault("custom_components", types.ModuleType("custom_components"))
+sys.modules.setdefault("custom_components.homgar", types.ModuleType("custom_components.homgar"))
+sys.modules.setdefault("custom_components.homgar.api", types.ModuleType("custom_components.homgar.api"))
+_load_module("custom_components.homgar.const", "custom_components/homgar/const.py")
+client_mod = _load_module("custom_components.homgar.api.client", "custom_components/homgar/api/client.py")
+
+import aiohttp  # the stub registered above  # noqa: E402
+
+PASS = 0
+FAIL = 0
+
+
+def check(name: str, condition: bool, detail: str = "") -> None:
+    global PASS, FAIL
+    if condition:
+        print(f"  ✅ {name}")
+        PASS += 1
+    else:
+        print(f"  ❌ {name}{': ' + detail if detail else ''}")
+        FAIL += 1
+
+
+_LOGIN_PAYLOAD = {
+    "code": 0, "ts": 1700000000000,
+    "data": {"token": "fresh", "refreshToken": "r", "tokenExpired": 3600, "user": {}},
+}
+
+
+class _FakeResp:
+    def __init__(self, status, payload):
+        self.status = status
+        self._payload = payload
+
+    async def json(self):
+        return self._payload
+
+    async def text(self):
+        return ""
+
+
+class _FakeReqCtx:
+    def __init__(self, action):
+        self._action = action
+
+    async def __aenter__(self):
+        if isinstance(self._action, BaseException):
+            raise self._action
+        status, payload = self._action
+        return _FakeResp(status, payload)
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _ScriptedSession:
+    def __init__(self, script: dict[str, list]):
+        self._script = {k: list(v) for k, v in script.items()}
+        self.calls: list[tuple[str, str]] = []
+
+    def _next(self, method: str, url: str):
+        self.calls.append((method, url))
+        if url.endswith("/auth/basic/app/login"):
+            return _FakeReqCtx((200, _LOGIN_PAYLOAD))
+        for suffix, actions in self._script.items():
+            if url.endswith(suffix) and actions:
+                return _FakeReqCtx(actions.pop(0))
+        raise AssertionError(f"No scripted action for {method} {url}")
+
+    def get(self, url, **kwargs):
+        return self._next("get", url)
+
+    def post(self, url, **kwargs):
+        return self._next("post", url)
+
+
+def _make_client(script):
+    session = _ScriptedSession(script)
+    client = client_mod.HomGarClient("31", "a@b.com", "pw", session, "homgar")
+    client._token = "tok"
+    client._refresh_token = "r"
+    client._token_expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
+    return client, session
+
+
+def _count(session, suffix):
+    return sum(1 for _m, url in session.calls if url.endswith(suffix))
+
+
+_CTL = "/app/device/controlWorkMode"
+_SET = "/app/device/setDeviceStatus"
+_SLEEPS: list[float] = []
+
+
+async def _fake_sleep(delay):
+    _SLEEPS.append(delay)
+
+
+async def _open_valve(client):
+    return await client.control_work_mode(
+        mid=1, addr=2, device_name="d", product_key="p", port=1, mode=1, duration=60,
+    )
+
+
+# --- the classifier itself --------------------------------------------------
+
+
+def _test_classifier():
+    f = client_mod._is_pre_send_error
+    check("connect timeout is pre-send",
+          f(aiohttp.ConnectionTimeoutError("Connection timeout to host https://x")) is True)
+    check("connector/DNS error is pre-send",
+          f(aiohttp.ClientConnectorError("Cannot connect to host x:443")) is True)
+
+    # The two traps this design is most likely to regress into.
+    check("read timeout is NOT pre-send (subclasses ServerTimeoutError)",
+          f(aiohttp.SocketTimeoutError("Timeout on reading data")) is False)
+    check("mid-flight ClientOSError is NOT pre-send (ClientConnectorError's base)",
+          f(aiohttp.ClientOSError("Connection reset by peer")) is False)
+
+    check("server disconnect is NOT pre-send",
+          f(aiohttp.ServerDisconnectedError("Server disconnected")) is False)
+    check("bare asyncio.TimeoutError is NOT pre-send (ambiguous)",
+          f(asyncio.TimeoutError("Connection timeout to host")) is False)
+    check("a 5xx-derived transient error is NOT pre-send",
+          f(client_mod.HomGarTransientError("controlWorkMode HTTP 503")) is False)
+
+
+# --- write path -------------------------------------------------------------
+
+
+async def _test_write_retries_connect_timeout():
+    """The reported failure: the command never reached the cloud, so resending
+    it cannot double-actuate."""
+    _SLEEPS.clear()
+    err = aiohttp.ConnectionTimeoutError(f"Connection timeout to host https://x{_CTL}")
+    script = {_CTL: [err, (200, {"code": 0, "data": {}})]}
+    client, session = _make_client(script)
+    raised = None
+    try:
+        # Returns an optional state string; None is a valid success here, so the
+        # assertion is that it did not raise.
+        await _open_valve(client)
+    except client_mod.HomGarApiError as e:
+        raised = e
+    check("valve command succeeds after a connect timeout", raised is None, f"raised {raised!r}")
+    check("it retried exactly once (2 POSTs)", _count(session, _CTL) == 2, str(session.calls))
+    check("it backed off once before resending", len(_SLEEPS) == 1, f"sleeps={_SLEEPS}")
+
+
+async def _test_write_retries_connector_error():
+    _SLEEPS.clear()
+    err = aiohttp.ClientConnectorError("Cannot connect to host region3.homgarus.com:443")
+    script = {_CTL: [err, (200, {"code": 0, "data": {}})]}
+    client, session = _make_client(script)
+    await _open_valve(client)
+    check("valve command succeeds after a DNS/connect error", _count(session, _CTL) == 2, str(session.calls))
+
+
+async def _test_write_does_not_retry_read_timeout():
+    """Post-send: the cloud may already be watering. Must fail fast."""
+    _SLEEPS.clear()
+    err = aiohttp.SocketTimeoutError("Timeout on reading data from socket")
+    script = {_CTL: [err, (200, {"code": 0, "data": {}})]}
+    client, session = _make_client(script)
+    raised = None
+    try:
+        await _open_valve(client)
+    except client_mod.HomGarApiError as e:
+        raised = e
+    check("read timeout on a write is NOT retried", _count(session, _CTL) == 1, str(session.calls))
+    check("read timeout surfaces to the caller", raised is not None)
+    check("no backoff slept on a non-retried write", len(_SLEEPS) == 0, f"sleeps={_SLEEPS}")
+
+
+async def _test_write_does_not_retry_disconnect():
+    _SLEEPS.clear()
+    err = aiohttp.ServerDisconnectedError("Server disconnected")
+    script = {_CTL: [err, (200, {"code": 0, "data": {}})]}
+    client, session = _make_client(script)
+    try:
+        await _open_valve(client)
+    except client_mod.HomGarApiError:
+        pass
+    check("server disconnect on a write is NOT retried", _count(session, _CTL) == 1, str(session.calls))
+
+
+async def _test_write_does_not_retry_5xx():
+    """A 503 means the request was delivered and the server answered."""
+    _SLEEPS.clear()
+    script = {_SET: [(503, {}), (200, {"code": 0})]}
+    client, session = _make_client(script)
+    raised = None
+    try:
+        await client.set_device_state(
+            home_id=1, device_name="d", mid=1, product_key="p", state={"port_1": True},
+        )
+    except client_mod.HomGarApiError as e:
+        raised = e
+    check("503 on a write is NOT retried", _count(session, _SET) == 1, str(session.calls))
+    check("503 on a write raises", raised is not None)
+
+
+async def _test_write_gives_up_after_one_retry():
+    """Bounded: a user is waiting on a button press, so one resend only."""
+    _SLEEPS.clear()
+    err = aiohttp.ConnectionTimeoutError("Connection timeout to host https://x")
+    script = {_CTL: [err] * 10}
+    client, session = _make_client(script)
+    raised = None
+    try:
+        await _open_valve(client)
+    except client_mod.HomGarApiError as e:
+        raised = e
+    check("a persistent connect timeout stops after 2 attempts",
+          _count(session, _CTL) == 2, str(session.calls))
+    check("it still raises HomGarTransientError",
+          isinstance(raised, client_mod.HomGarTransientError), f"got {type(raised).__name__}")
+
+
+def _test_backoff_constant_sane():
+    b = client_mod._WRITE_PRE_SEND_RETRY_BACKOFF
+    check("write backoff is a non-empty tuple", isinstance(b, tuple) and len(b) >= 1, f"got {b!r}")
+    check("write retries at most once (a user is waiting)", len(b) == 1, f"got {b!r}")
+    check("write backoff is short (<=2s)", sum(b) <= 2, f"sum={sum(b)}")
+
+
+def main() -> int:
+    print("Write-path pre-send retry tests (issue #82 follow-up)")
+    _test_classifier()
+    _test_backoff_constant_sane()
+    original_sleep = client_mod.asyncio.sleep
+    client_mod.asyncio.sleep = _fake_sleep
+    try:
+        asyncio.run(_test_write_retries_connect_timeout())
+        asyncio.run(_test_write_retries_connector_error())
+        asyncio.run(_test_write_does_not_retry_read_timeout())
+        asyncio.run(_test_write_does_not_retry_disconnect())
+        asyncio.run(_test_write_does_not_retry_5xx())
+        asyncio.run(_test_write_gives_up_after_one_retry())
+    finally:
+        client_mod.asyncio.sleep = original_sleep
+    print(f"\n{PASS} passed, {FAIL} failed")
+    return 1 if FAIL else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Third PR from #82, prompted by a live valve-control failure reported on 2026-08-10.

## The report

Manually opening a valve failed outright:

```
HomGarTransientError: controlWorkMode: Connection timeout to host …/app/device/controlWorkMode
```

The valve did not open; an immediate second manual attempt succeeded. The reporter correctly attributed it to our deliberate `retry=False` on writes and treated it as an accepted trade-off.

It isn't one. That failure never needed to surface.

## Why this specific failure is safe to retry

v3.0.42's blanket no-retry on writes exists for a real reason: `controlWorkMode` is absolute ("run for N seconds"), not idempotent, so resending after the cloud already accepted it could re-actuate irrigation. But that reasoning only applies to failures that *might* have been delivered.

This one provably wasn't. aiohttp raises that message from `_connect_and_send_request` when `connector.connect()` times out — **before any request bytes are written**:

```python
try:
    conn = await self._connector.connect(req, traces=traces, timeout=real_timeout)
except asyncio.TimeoutError as exc:
    raise ConnectionTimeoutError(f"Connection timeout to host {req.url}")
```

No connection, no request, nothing for the cloud to have acted on. A resend cannot double-actuate.

## Change

Writes now retry **only** provably pre-send failures, once, after 1s:

| Failure | Sent? | Retried on a write |
|---|---|---|
| `ConnectionTimeoutError` | never | **yes** |
| `ClientConnectorError` (DNS/refused) | never | **yes** |
| `SocketTimeoutError` (read) | maybe | no |
| `ServerDisconnectedError` | maybe | no |
| mid-flight `ClientOSError` | maybe | no |
| HTTP 5xx | delivered | no |

One retry only — a user is waiting on a button press. Reads are untouched; they already retry everything transient. The no-double-actuation guarantee is fully intact.

**Two traps** make this easy to get subtly wrong, and both are pinned by tests:
- `ClientConnectorError` subclasses `ClientOSError`, which *also* covers mid-flight socket errors — matching the base would admit post-send failures.
- `ConnectionTimeoutError` and `SocketTimeoutError` both subclass `ServerTimeoutError` — matching *that* base would admit read timeouts.

Both class names are resolved with `getattr`, so an aiohttp lacking them drops the retry rather than breaking import. An empty tuple degrades cleanly to the previous fail-fast behaviour. (This also surfaced a real fragility: the first cut hard-required `aiohttp.ClientConnectorError` at import and broke an unrelated test's aiohttp stub.)

## Also fixed

The `failed after N attempts` warning reported the attempt *ceiling* rather than attempts actually made, so a fail-fast write claimed more tries than it had. Now reports the true count.

## Tests

`tests/run_write_presend_retry_tests.py` (22 checks) — the classifier against aiohttp's real hierarchy including both traps, plus the write path end to end: connect timeout retries once and succeeds, read timeout / disconnect / 503 never retried, persistent connect timeout stops after two attempts. Wired into the pre-commit Docker gate. Full gate green.

No version bump — changelog entry sits under `## [Unreleased]`.

## Not addressed here

The reporter's `controlWorkMode returned code 4 (busy/already in state)` warnings were traced by him to his own automation sending redundant close commands. Not an integration fault; no change made.
