### PR TITLE
fix(api): null status payload no longer blocks setup, add diagnostics (v3.0.47)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,7 @@ body:
 
         **Compatibility note:** This integration supports HomGar / RainPoint Smart+ / RainPoint Home H-series devices. RainPoint-TY / Tuya T-series devices are not supported; login or discovery failures for RainPoint-TY accounts are expected and should not be filed as integration bugs. See the wiki compatibility guide: https://github.com/brettmeyerowitz/homeassistant-homgar/wiki/RainPoint-App-and-Device-Compatibility
 
-        **Latest released integration version:** `3.0.24`
+        **Latest released integration version:** `3.0.47`
         
         Please update to the latest release and restart Home Assistant before opening a bug report.
   
@@ -102,6 +102,24 @@ body:
       required: false
   
   - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostics (strongly preferred over logs)
+      description: |
+        **Settings → Devices & Services → HomGar/RainPoint Cloud → ⋮ → Download diagnostics**,
+        then attach the file here by dragging it into this box.
+
+        This is by far the most useful thing you can provide: it captures the device
+        rows and raw cloud responses in full, so we do not have to ask you for
+        specific log lines one at a time. Your email, tokens, MAC addresses and
+        device credentials are redacted automatically before the file is written.
+
+        Requires integration version 3.0.47 or newer.
+      placeholder: Drag the downloaded .json file here.
+    validations:
+      required: false
+
+  - type: textarea
     id: logs
     attributes:
       label: Home Assistant Logs
@@ -119,8 +137,8 @@ body:
     id: integration_version
     attributes:
       label: Integration Version
-      description: What exact version of the HomGar/RainPoint integration are you using? Latest release is 3.0.24.
-      placeholder: "e.g. 3.0.24"
+      description: What exact version of the HomGar/RainPoint integration are you using? Latest release is 3.0.47.
+      placeholder: "e.g. 3.0.47"
     validations:
       required: true
   
@@ -159,7 +177,7 @@ body:
       options:
         - label: I have searched existing issues to ensure this is not a duplicate
           required: true
-        - label: I have updated to the latest released version (3.0.24) and restarted Home Assistant
+        - label: I have updated to the latest released version (3.0.47) and restarted Home Assistant
           required: true
         - label: I have provided steps to reproduce the issue
           required: true

--- a/.github/ISSUE_TEMPLATE/device_support.yml
+++ b/.github/ISSUE_TEMPLATE/device_support.yml
@@ -16,7 +16,7 @@ body:
 
         **Compatibility note:** This integration supports HomGar / RainPoint Smart+ / RainPoint Home H-series devices. RainPoint-TY / Tuya T-series devices are not supported by this integration. If your model starts with `T` or only pairs with the RainPoint-TY app, please try a Tuya-compatible Home Assistant integration instead. See the wiki compatibility guide: https://github.com/brettmeyerowitz/homeassistant-homgar/wiki/RainPoint-App-and-Device-Compatibility
 
-        **Latest released integration version:** `3.0.24`
+        **Latest released integration version:** `3.0.47`
         
         Please update to the latest release and restart Home Assistant before opening a new device support request.
   
@@ -149,8 +149,8 @@ body:
     id: integration_version
     attributes:
       label: Integration Version
-      description: What exact version of the HomGar/RainPoint integration are you using? Latest release is 3.0.24.
-      placeholder: "e.g. 3.0.24"
+      description: What exact version of the HomGar/RainPoint integration are you using? Latest release is 3.0.47.
+      placeholder: "e.g. 3.0.47"
     validations:
       required: true
   
@@ -179,7 +179,7 @@ body:
       options:
         - label: I have attached screenshots from the RainPoint/HomGar app showing actual readings
           required: true
-        - label: I have updated to the latest released version (3.0.24) and restarted Home Assistant
+        - label: I have updated to the latest released version (3.0.47) and restarted Home Assistant
           required: true
         - label: I have provided payloads from HA debug logs that match my app screenshots
           required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.0.47] - 2026-08-28
+
+### 🐛 Bug Fixes
+- **A device with no cloud status no longer blocks the whole integration from starting** — reported in [#97](https://github.com/brettmeyerowitz/homeassistant-homgar/issues/97). An account containing an HCS048B failed setup entirely with `Unexpected HomGar error: 'NoneType' object has no attribute 'get'`, retrying every five seconds forever. The cloud answers `{"code": 0, "msg": "SUCCESS", "data": null}` for a device that has no status to report, and `data.get("data", {})` does not defend against that — a default only applies when the key is *absent*, and here it is present and explicitly null. The `None` was stored and detonated one poll later. Every response now passes through a single guard that substitutes the default for a null while leaving a genuinely empty answer (`{}`, `[]`, `0`) untouched, since "the server said empty" and "the server said nothing" are different facts. Applied to all six extraction points, not just the one that crashed.
+  - The affected device is a Bluetooth water flow meter. Its readings reach the cloud only when the phone app uploads them over BLE, so the cloud holds nothing of its own to serve. It will now appear without readings rather than preventing every other device on the account from loading — the honest outcome, since there is nothing for this integration to read.
+
+### ✨ New
+- **Download diagnostics** — the integration now supports Home Assistant's standard diagnostics download (**Settings → Devices & Services → HomGar/RainPoint → ⋮ → Download diagnostics**). Device-support reports previously depended on hand-pasted logs, which routinely omitted the one line that mattered; #97's report began immediately after it. The download captures the shipped catalogue version, any model the catalogue has never seen, the full cloud device rows, and the raw status envelopes exactly as received — so an explicit `"data": null` arrives as null rather than being normalised away. Account identifiers and device credentials (email, tokens, `iotId`, `productKey`, `deviceName`, `mac`, `hid`, and the entry title, which embeds the account email) are redacted; `mid`, `model`, `modelCode` and the raw payload frames are deliberately kept, because they are the diagnostic content itself.
+
 ## [3.0.46] - 2026-08-27
 
 ### 🐛 Bug Fixes

--- a/custom_components/homgar/__init__.py
+++ b/custom_components/homgar/__init__.py
@@ -615,15 +615,6 @@ async def async_setup_services(hass: HomeAssistant) -> None:
     )
 
 
-async def async_get_diagnostic_info(hass: HomeAssistant, entry: ConfigEntry) -> dict:
-    """Return diagnostic information for this integration."""
-    return {
-        "entry_id": entry.entry_id,
-        "title": entry.title,
-        "domain": DOMAIN,
-        "supports_reload": True,
-    }
-
 
 async def async_reload_integration(hass: HomeAssistant, entry_id: str) -> bool:
     """Reload the HomGar integration."""

--- a/custom_components/homgar/api/client.py
+++ b/custom_components/homgar/api/client.py
@@ -39,6 +39,22 @@ _REQUEST_TIMEOUT = aiohttp.ClientTimeout(total=30, connect=20, sock_connect=20)
 # value works; this mirrors the RainPoint/HomGar phone app. See issue #76.
 _USER_AGENT = "okhttp/4.9.2"
 
+
+def _response_payload(data: dict, default):
+    """Return a response's ``data`` section, substituting *default* for null.
+
+    ``data.get("data", default)`` is not enough: the cloud answers
+    ``{"code": 0, "msg": "SUCCESS", "data": null}`` for a device that has no
+    status to report, and a dict default only applies when the key is *absent*.
+    The explicit null therefore leaked through as None and blew up one loop
+    later as ``'NoneType' object has no attribute 'get'``. See issue #97.
+
+    A present-but-empty payload (``{}`` / ``[]``) is passed through unchanged —
+    it is a real answer, not a missing one.
+    """
+    value = data.get("data")
+    return default if value is None else value
+
 # Transient upstream failures worth retrying within a single coordinator poll:
 # connection resets, DNS/connect timeouts, and 5xx from the cloud. The cloud
 # (region3.homgarus.com) intermittently returns these while the RainPoint app
@@ -590,7 +606,7 @@ class HomGarClient:
             data = await self._request_json("get", url, what="list_homes", headers=self._auth_headers())
         if data.get("code") != 0:
             raise HomGarApiError(f"list_homes failed: {data}")
-        return data.get("data", [])
+        return _response_payload(data, [])
 
     async def get_devices_by_hid(self, hid: int) -> list[dict]:
         """Get devices by home ID (HID)."""
@@ -610,7 +626,7 @@ class HomGarClient:
             )
         if data.get("code") != 0:
             raise HomGarApiError(f"getDeviceByHid failed: {data}")
-        return data.get("data", [])
+        return _response_payload(data, [])
 
     async def get_multiple_device_status(self, devices: list) -> list[dict]:
         """Get status for multiple devices in one call."""
@@ -642,7 +658,7 @@ class HomGarClient:
             raise HomGarApiError(f"Device status API error: {data.get('msg')}")
         
         # Convert response format - API returns "status" but coordinator expects "subDeviceStatus"
-        response_data = data.get("data", [])
+        response_data = _response_payload(data, [])
         converted_data = []
         for device in response_data:
             converted_device = device.copy()
@@ -672,7 +688,28 @@ class HomGarClient:
             )
         if data.get("code") != 0:
             raise HomGarApiError(f"getDeviceStatus failed: {data}")
-        return data.get("data", {})
+        return _response_payload(data, {})
+
+    async def raw_device_status(self, mid: int) -> dict:
+        """Return getDeviceStatus's full envelope, unnormalised, for diagnostics.
+
+        ``get_device_status`` deliberately substitutes ``{}`` for a null payload
+        so callers cannot crash on it (issue #97), which also makes "no status at
+        all" indistinguishable from "empty status" downstream. Diagnostics need
+        that distinction — a Bluetooth device with no cloud mirror answers
+        ``"data": null`` — so this returns ``code``/``msg``/``data``/``ts`` as
+        received. Read-only; no reauth retry, since a diagnostics download should
+        report a token problem rather than paper over it.
+        """
+        await self._ensure_auth()
+        url = f"{self._base_url}/app/device/getDeviceStatus"
+        return await self._request_json(
+            "get",
+            url,
+            what="getDeviceStatus(diagnostics)",
+            headers=self._auth_headers(),
+            params={"mid": mid},
+        )
 
     async def subscribe_status(
         self,
@@ -738,7 +775,7 @@ class HomGarClient:
             _LOGGER.debug("API response (after reauth): subscribe_status data=%s", data)
         if data.get("code") != 0:
             raise HomGarApiError(f"subscribeStatus failed: {data}")
-        return data.get("data", {})
+        return _response_payload(data, {})
 
     async def set_device_state(self, home_id: int, device_name: str, mid: int, product_key: str, state: dict) -> bool:
         """Set device state."""
@@ -808,7 +845,7 @@ class HomGarClient:
             return []
         
         # Extract models from data['data']['models'] structure
-        data_section = data.get("data", {})
+        data_section = _response_payload(data, {})
         if isinstance(data_section, dict):
             result = data_section.get("models", [])
         else:

--- a/custom_components/homgar/diagnostics.py
+++ b/custom_components/homgar/diagnostics.py
@@ -1,0 +1,143 @@
+"""Diagnostics for the HomGar/RainPoint integration.
+
+Device-support issues used to be worked from hand-pasted logs, which meant the
+one line that mattered was routinely missing — issue #97's report began directly
+after the ``Found N devices for HID`` line that would have identified the
+device. This exposes Home Assistant's standard "Download diagnostics" button
+instead, so a reporter can hand over the full picture in one attachment.
+
+What is captured is chosen for diagnosing *unknown hardware*: the raw cloud rows
+and status envelopes exactly as received (an explicit ``"data": null`` must
+arrive as null, not normalised away), the catalogue version the install is
+running, and any model our catalogue has never seen.
+
+Everything is redacted through ``TO_REDACT`` before it leaves, because these
+files get pasted into public issues. ``mid`` is deliberately retained: it is a
+device identifier rather than a credential, and keeping it lets a maintainer
+follow one device through a long thread.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import CONF_APP_TYPE, DOMAIN
+from .decoder import _MODELS_FILE, _load_models, get_model_info
+
+_LOGGER = logging.getLogger(__name__)
+
+# Account identifiers and device credentials. Anything here can identify the
+# reporter or be replayed against their account, so none of it may survive into
+# a file destined for a public issue thread.
+TO_REDACT = {
+    "email",
+    "phoneOrEmail",
+    "password",
+    "token",
+    "refreshToken",
+    "deviceId",
+    "iotId",
+    "productKey",
+    "deviceName",
+    "mac",
+    "hid",
+    "did",
+    "homeName",
+    "name",
+    # The config entry title is assembled as "HomGar/RainPoint (<email>)", so the
+    # account address rides along inside free text. Key-based redaction cannot
+    # see a substring, so the whole field goes — caught by auditing a real
+    # download rather than by reading the key list.
+    "title",
+}
+
+
+def _redact(data: Any) -> Any:
+    """Redact credentials and account identifiers, recursively."""
+    return async_redact_data(data, TO_REDACT)
+
+
+def _catalogue_summary() -> dict:
+    """Describe the shipped product catalogue.
+
+    The catalogue is a static snapshot, so a device newer than it decodes as
+    "unknown model" for reasons that have nothing to do with the user's setup.
+    Reporting its version up front makes that immediately visible.
+    """
+    models = _load_models()
+    version = None
+    try:
+        import json
+
+        with open(_MODELS_FILE, encoding="utf-8") as handle:
+            version = json.load(handle).get("data", {}).get("version")
+    except Exception as err:  # noqa: BLE001 — diagnostics must never fail hard
+        _LOGGER.debug("Could not read catalogue version: %s", err)
+    return {
+        "version": version,
+        "model_count": len(models),
+        "source": str(_MODELS_FILE),
+    }
+
+
+def _unknown_models(hubs: list[dict]) -> list[str]:
+    """Return models present on the account but absent from our catalogue.
+
+    These are the devices that cannot decode, so naming them is usually the
+    whole answer to a device-support report.
+    """
+    seen: set[str] = set()
+    for hub in hubs or []:
+        candidates = [hub.get("model")]
+        candidates.extend(sub.get("model") for sub in (hub.get("subDevices") or []))
+        for model in candidates:
+            if model and get_model_info(model) is None:
+                seen.add(model)
+    return sorted(seen)
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict:
+    """Return redacted diagnostics for one config entry."""
+    entry_data = hass.data.get(DOMAIN, {}).get(entry.entry_id, {}) or {}
+    coordinator = entry_data.get("coordinator")
+    client = entry_data.get("client")
+    data = (coordinator.data if coordinator else None) or {}
+    hubs = data.get("hubs") or []
+
+    diagnostics: dict[str, Any] = {
+        "entry": {
+            "title": entry.title,
+            "app_type": entry.data.get(CONF_APP_TYPE),
+            "version": entry.version,
+        },
+        "catalogue": _catalogue_summary(),
+        "unknown_models": _unknown_models(hubs),
+        "hubs": hubs,
+        "status": data.get("status") or {},
+        "sensors": data.get("sensors") or {},
+        "mqtt_diagnostics": data.get("mqtt_diagnostics") or {},
+    }
+
+    # Raw, unnormalised envelopes. The client's own null-guard makes a missing
+    # payload indistinguishable from an empty one by the time it reaches the
+    # coordinator, so fetch these directly — a `"data": null` is the signature
+    # of a device with no cloud status at all (issue #97) and must be visible.
+    raw: dict[str, Any] = {}
+    if client is not None:
+        for hub in hubs:
+            mid = hub.get("mid")
+            if mid is None:
+                continue
+            try:
+                raw[str(mid)] = await client.raw_device_status(int(mid))
+            except Exception as err:  # noqa: BLE001 — never fail the download
+                raw[str(mid)] = {"error": f"{type(err).__name__}: {err}"}
+    diagnostics["raw_device_status"] = raw
+
+    return _redact(diagnostics)

--- a/custom_components/homgar/manifest.json
+++ b/custom_components/homgar/manifest.json
@@ -15,5 +15,5 @@
     "requirements": [
         "paho-mqtt>=1.6.0"
     ],
-    "version": "3.0.46"
+    "version": "3.0.47"
 }

--- a/tests/run_diagnostics_tests.py
+++ b/tests/run_diagnostics_tests.py
@@ -1,0 +1,126 @@
+"""Tests for the diagnostics platform's redaction and summarisation.
+
+Diagnostics exist to be pasted into public GitHub issues, so the redaction set is
+a privacy boundary, not a nicety: anything identifying the account or usable as a
+device credential must never survive a download. Equally, over-redacting destroys
+the reason the download exists — ``model``, ``modelCode`` and the raw payload
+frames are the diagnostic payload itself, and blanking them would leave us asking
+for hand-pasted logs all over again (which is how issue #97 stalled).
+
+``mid`` is deliberately kept: it is a device identifier rather than a credential,
+and retaining it lets a maintainer correlate devices across a long issue thread.
+
+Runs in the ha-test container against the deployed integration at /config.
+"""
+import sys
+
+sys.path.insert(0, "/config")
+
+from custom_components.homgar.diagnostics import (  # noqa: E402
+    TO_REDACT,
+    _catalogue_summary,
+    _redact,
+    _unknown_models,
+)
+
+PASS = 0
+FAIL = 0
+R = "**REDACTED**"
+
+
+def check(name, cond, detail=""):
+    global PASS, FAIL
+    if cond:
+        print(f"  ✅ {name}"); PASS += 1
+    else:
+        print(f"  ❌ {name}{': ' + detail if detail else ''}"); FAIL += 1
+
+
+print("\n🧪 _redact — credentials and account identifiers must not survive")
+
+for field in ("email", "password", "token", "refreshToken", "deviceId",
+              "iotId", "productKey", "deviceName", "mac", "hid"):
+    check(f"{field} is redacted", _redact({field: "secret"})[field] == R,
+          f"got {_redact({field: 'secret'})[field]!r}")
+
+# Redaction must reach into the nested shapes the cloud actually returns:
+# hubs carry subDevices, and status envelopes nest under "data".
+nested = {"data": {"hubs": [{"mid": 1, "iotId": "abc", "subDevices": [{"mac": "aa:bb"}]}]}}
+out = _redact(nested)
+check(
+    "nested list-of-dicts is redacted",
+    out["data"]["hubs"][0]["subDevices"][0]["mac"] == R,
+    f"got {out['data']['hubs'][0]['subDevices'][0]['mac']!r}",
+)
+check("nested dict is redacted", out["data"]["hubs"][0]["iotId"] == R)
+
+
+print("\n🧪 _redact — diagnostic value must be preserved")
+
+# These are the whole point of the download. Redacting them would make the
+# artefact useless for device-support work.
+keep = {
+    "mid": 356840,
+    "model": "HCS048B",
+    "modelCode": 283,
+    "softVer": "1.1.1041",
+    "value": "10#E1BB00DC01856002881EC6500000FF0FCD31391A",
+    "subDeviceStatus": [{"id": "D01", "value": "10#ABC"}],
+}
+kept = _redact(keep)
+check("mid is kept (identifier, not credential)", kept["mid"] == 356840)
+check("model is kept", kept["model"] == "HCS048B")
+check("modelCode is kept", kept["modelCode"] == 283)
+check("softVer is kept", kept["softVer"] == "1.1.1041")
+check("raw payload frame is kept", kept["value"] == keep["value"])
+check("nested payload frame is kept", kept["subDeviceStatus"][0]["value"] == "10#ABC")
+
+# A null status is the #97 signature and must reach us intact, not normalised.
+null_env = _redact({"code": 0, "msg": "SUCCESS", "data": None, "ts": 1})
+check("an explicit null data is preserved verbatim", null_env["data"] is None)
+check("the response code is preserved", null_env["code"] == 0)
+
+check("mid is not in the redaction set", "mid" not in TO_REDACT)
+
+# Regression: key-based redaction cannot see an identifier embedded in free
+# text. The config entry title is built as "HomGar/RainPoint (<email>)", so a
+# real download leaked the account email even though "email" was redacted —
+# caught by auditing an actual downloaded file rather than trusting the key set.
+leaky_title = "HomGar/RainPoint (someone@example.com)"
+check(
+    "entry title is redacted (it embeds the account email)",
+    _redact({"title": leaky_title})["title"] == R,
+    f"got {_redact({'title': leaky_title})['title']!r}",
+)
+check("title is in the redaction set", "title" in TO_REDACT)
+
+
+print("\n🧪 _catalogue_summary — how stale is this install's catalogue?")
+
+summary = _catalogue_summary()
+check("reports a catalogue version", summary.get("version") is not None)
+check("reports a model count", isinstance(summary.get("model_count"), int)
+      and summary["model_count"] > 0, f"got {summary.get('model_count')!r}")
+
+
+print("\n🧪 _unknown_models — name hardware our catalogue has never seen")
+
+hubs = [
+    {"model": "HWG023WRF", "subDevices": [{"model": "HCS012ARF"}]},
+    {"model": "HZZ999NEW", "subDevices": [{"model": "HQQ000ALSONEW"}]},
+]
+unknown = _unknown_models(hubs)
+check("an unknown hub model is reported", "HZZ999NEW" in unknown, f"got {unknown!r}")
+check("an unknown sub-device model is reported", "HQQ000ALSONEW" in unknown)
+check("a known hub model is not reported", "HWG023WRF" not in unknown)
+check("a known sub-device model is not reported", "HCS012ARF" not in unknown)
+check("result is sorted and deduplicated", unknown == sorted(set(unknown)))
+check("no hubs yields no unknown models", _unknown_models([]) == [])
+
+
+print("\n" + "=" * 50)
+print(f"Results: {PASS}/{PASS + FAIL} passed, {FAIL} failed")
+if FAIL:
+    print("❌ TESTS FAILED")
+    sys.exit(1)
+print("✅ ALL TESTS PASSED")

--- a/tests/run_null_payload_tests.py
+++ b/tests/run_null_payload_tests.py
@@ -1,0 +1,111 @@
+"""Regression tests: a null ``data`` payload must not crash the coordinator.
+
+Issue #97: an account containing an HCS048B (a Bluetooth water flow meter) could
+not set up at all. ``getDeviceStatus`` answers ``{"code": 0, "msg": "SUCCESS",
+"data": null}`` for a device that has no hub-side status, because a Bluetooth
+device's readings only reach the cloud when the phone app uploads them via
+``/app/device/coap/state`` — the cloud is a passive mirror, not a live source.
+
+``data.get("data", {})`` does not defend against that: a dict default only
+applies when the key is *absent*, and here it is present and null. The client
+therefore returned ``None``, the coordinator stored it, and the next loop raised
+``AttributeError: 'NoneType' object has no attribute 'get'`` — turning a device
+we simply cannot read into a setup-blocking crash loop.
+
+The invariant this locks down: ``_response_payload`` never returns None, so no
+caller can inherit that crash, whatever the cloud sends.
+
+Runs in the ha-test container against the deployed integration at /config.
+"""
+import sys
+
+sys.path.insert(0, "/config")
+
+from custom_components.homgar.api.client import _response_payload  # noqa: E402
+
+PASS = 0
+FAIL = 0
+
+
+def check(name, cond, detail=""):
+    global PASS, FAIL
+    if cond:
+        print(f"  ✅ {name}"); PASS += 1
+    else:
+        print(f"  ❌ {name}{': ' + detail if detail else ''}"); FAIL += 1
+
+
+print("\n🧪 _response_payload — an explicit null must not leak through as None")
+
+# The exact #97 response.
+crash_response = {"code": 0, "msg": "SUCCESS", "data": None, "ts": 1787914495010}
+check(
+    "the #97 response yields the default, not None",
+    _response_payload(crash_response, {}) == {},
+    f"got {_response_payload(crash_response, {})!r}",
+)
+# And the result is safe to use the way the coordinator uses it — this is the
+# call that actually raised AttributeError at coordinator.py:362.
+check(
+    "the result supports .get() as the coordinator expects",
+    _response_payload(crash_response, {}).get("subDeviceStatus", []) == [],
+)
+check(
+    "a missing key still yields the default",
+    _response_payload({"code": 0}, {}) == {},
+)
+check(
+    "a list default is honoured for null",
+    _response_payload({"code": 0, "data": None}, []) == [],
+)
+
+print("\n🧪 _response_payload — real payloads pass through untouched")
+
+check(
+    "a populated dict payload passes through",
+    _response_payload({"data": {"subDeviceStatus": [1]}}, {}) == {"subDeviceStatus": [1]},
+)
+check(
+    "a populated list payload passes through",
+    _response_payload({"data": [{"mid": 1}]}, []) == [{"mid": 1}],
+)
+# Falsy-but-real answers must be preserved. Substituting the default here would
+# silently rewrite "the server said empty" into "the server said nothing",
+# which is a different fact and would mask genuine empty responses.
+check(
+    "an empty dict payload is preserved, not replaced",
+    _response_payload({"data": {}}, {"x": 1}) == {},
+    f"got {_response_payload({'data': {}}, {'x': 1})!r}",
+)
+check(
+    "an empty list payload is preserved, not replaced",
+    _response_payload({"data": []}, [{"x": 1}]) == [],
+    f"got {_response_payload({'data': []}, [{'x': 1}])!r}",
+)
+check(
+    "a zero payload is preserved, not replaced",
+    _response_payload({"data": 0}, {}) == 0,
+    f"got {_response_payload({'data': 0}, {})!r}",
+)
+
+print("\n🧪 the invariant: never None, whatever the cloud sends")
+
+for envelope in (
+    {"data": None},
+    {},
+    {"data": {}},
+    {"data": []},
+    {"code": 0, "msg": "SUCCESS", "data": None, "ts": 1},
+):
+    check(
+        f"never None for {envelope!r}",
+        _response_payload(envelope, {}) is not None,
+    )
+
+
+print("\n" + "=" * 50)
+print(f"Results: {PASS}/{PASS + FAIL} passed, {FAIL} failed")
+if FAIL:
+    print("❌ TESTS FAILED")
+    sys.exit(1)
+print("✅ ALL TESTS PASSED")


### PR DESCRIPTION
## The bug

An account containing an **HCS048B** could not set up at all — every device on it was lost, not just the one:

```
Unexpected HomGar error: 'NoneType' object has no attribute 'get'
... Retrying in 5 seconds
```

Reported in #97 (left open deliberately — see below).

`getDeviceStatus` answers `{"code": 0, "msg": "SUCCESS", "data": null}` for a device with no status to report. `data.get("data", {})` does not defend against that: a default only applies when the key is **absent**, and here it is present and explicitly `null`. The `None` was stored by the coordinator and detonated on the next poll at `coordinator.py:362`.

All six extraction points now share one guard, `_response_payload()`. It substitutes the default for a null but passes a genuinely empty answer (`{}`, `[]`, `0`) through unchanged — *"the server said empty"* and *"the server said nothing"* are different facts, and collapsing them would mask real responses.

### Why this device has no status

HCS048B is a Bluetooth water flow meter. Its readings reach the cloud only when the phone app uploads them over BLE (`/app/device/coap/state`), so the cloud is a passive mirror with nothing of its own to serve. It now appears without readings rather than blocking the whole account from loading — the honest outcome, since there is nothing here for this integration to read.

## Diagnostics download

Device-support reports depended on hand-pasted logs, which routinely omitted the decisive line — #97's report began *immediately after* the `Found N devices for HID` line that would have identified the device.

**Settings → Devices & Services → HomGar/RainPoint → ⋮ → Download diagnostics** now captures the catalogue version, any model the catalogue has never seen, full cloud device rows, and raw status envelopes as received (so an explicit `null` arrives as `null`).

### Redaction

Redacted: `email`, `password`, `token`, `refreshToken`, `deviceId`, `iotId`, `productKey`, `deviceName`, `mac`, `hid`, `did`, `homeName`, `name`, `title`.

Kept on purpose: `mid`, `model`, `modelCode`, `softVer` and the raw payload frames — they are the diagnostic content itself.

`title` is worth calling out. The unit tests passed on the original key list, but auditing a **real downloaded file** showed the account email still present: the entry title is built as `HomGar/RainPoint (<email>)`, and `async_redact_data` matches keys, not substrings. Caught, test added, fixed, re-audited:

```
account email/strings : none
MAC-shaped values     : 0
token-shaped values   : 0
**REDACTED**          : 33
```

## Also

- Removes the dead `async_get_diagnostic_info` stub (defined, never called).
- Issue templates advertised **3.0.24** as current in six places — which is why #97's reporter ticked a checkbox claiming 3.0.24 while running 3.0.46. Now 3.0.47, with a diagnostics upload field above the logs field.

## Testing

- 2 new runners (`run_null_payload_tests.py`, `run_diagnostics_tests.py`), written test-first
- All **30** runners pass; decoder suite **84/84**
- Verified on `ha-test`: clean restart, 51 entities, **0 unavailable**, diagnostics download exercised through the UI and audited for leaks

## Caveats

- **Not verified on real HCS048B hardware** — neither maintainer owns one. The evidence is a unit test reproducing the reporter's exact response envelope. **#97 stays open** until they confirm.
- The product catalogue is still the April snapshot (`1775119505345`). Refreshing it brings dp changes including a `STA_RSSI2`→`STA_RSRP` rename, so that stays a separate breaking change.