### PR TITLE
docs(releasing): don't repeat the version in the release title

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -15,6 +15,29 @@ bash scripts/pre-commit-docker-test.sh
 6. Create and push tag `vX.Y.Z`
 7. Create the GitHub release with `gh` using a notes file
 
+## Release Title Rule
+
+**Do not begin the release title with the version number.**
+
+HACS renders the update dialog as `<tag> - <release name>`, so a title of
+`v3.0.47 — a null status no longer blocks setup` displays to users as:
+
+```
+v3.0.47 - v3.0.47 — a null status no longer blocks setup
+```
+
+Title the release with the change only:
+
+```bash
+gh release create v3.0.47 \
+  --title "A null status no longer blocks setup, plus diagnostics downloads" \
+  --notes-file notes.md
+```
+
+Releases up to and including v3.0.46 repeat the version and render doubled in
+HACS. They are left as-is rather than retitled, since editing a published
+release rewrites what existing users already saw.
+
 ## Notes File Rule
 
 When using `gh`, write multi-line release notes to a file first and pass:


### PR DESCRIPTION
HACS renders its update dialog as `<tag> - <release name>`. Because our release titles begin with the version, users see it twice:

> **v3.0.47 - v3.0.47 — a null status no longer blocks setup, plus diagnostics downloads**

Every release up to and including v3.0.46 does this and renders doubled.

Records the rule in `docs/releasing.md` so new releases title the change only. The v3.0.47 release has already been retitled to `A null status no longer blocks setup, plus diagnostics downloads`, which now renders correctly.

Existing releases are deliberately left alone — editing a published release rewrites what users have already seen, for no functional gain.