### PR TITLE
fix(sensor): water volumes no longer read negative on the Energy dashboard (v3.0.48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.0.48] - 2026-08-28
+
+### 🐛 Bug Fixes
+- **Water volumes no longer produce negative readings on the Energy dashboard** — reported in [#96](https://github.com/brettmeyerowitz/homeassistant-homgar/issues/96). **Last Session Volume** was declared as a cumulative meter (`state_class: total`), which makes Home Assistant derive long-term statistics from the difference between consecutive readings. It is not a meter — it is a snapshot of the most recent watering session, and it drops back down after every run. A 10 L session followed by a 2 L one was therefore recorded as **−8 L** of water use. It is now a `measurement`, so it reports its own value and contributes no bogus totals.
+  - Correcting the state class discards the `sum` statistics previously accumulated for these sensors. Those sums were the negative ones, so this is a cleanup rather than a loss, but Home Assistant may show a one-off statistics notice.
+
+### ✨ New
+- **Total Water Volume** — valves such as the HTV245FRF report only the last session's volume and carry no cumulative counter at all, so there was nothing to put on the Energy dashboard once the above was fixed. A running total is now derived per zone by summing completed sessions, exposed as `total_increasing` and restored across restarts.
+  - Sessions are counted using the device's own event timestamp rather than by watching the volume change. Two consecutive sessions using the same amount of water — the normal result of a fixed-duration schedule — are indistinguishable by value alone and would otherwise be silently counted once.
+  - Created only for valves that report no hardware total of their own. Devices that already expose a real cumulative counter keep using it and do not gain a second, competing meter.
+  - Sessions that complete while Home Assistant is stopped cannot be counted: the cloud only ever exposes the *most recent* session, so there is no history to catch up on.
+
 ## [3.0.47] - 2026-08-28
 
 ### 🐛 Bug Fixes

--- a/custom_components/homgar/manifest.json
+++ b/custom_components/homgar/manifest.json
@@ -15,5 +15,5 @@
     "requirements": [
         "paho-mqtt>=1.6.0"
     ],
-    "version": "3.0.47"
+    "version": "3.0.48"
 }

--- a/custom_components/homgar/sensor.py
+++ b/custom_components/homgar/sensor.py
@@ -15,6 +15,7 @@ from homeassistant.const import EntityCategory
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
@@ -28,6 +29,7 @@ from .const import (
 )
 from .coordinator import HomGarCoordinator, _clean_firmware
 from .sensor_defs import FIELD_SENSOR_MAP, sensor_fields_for_data
+from .water_total import accumulate_session
 from .decoder import get_valve_ports
 from .diagnostic_sensors import (
     HomGarFirmwareVersionSensor,
@@ -142,6 +144,8 @@ async def async_setup_entry(
                         port_fields.update(_OPTIONAL_VALVE_PORT_SENSOR_FIELDS)
                     for field in sorted(port_fields):
                         entities.append(HomGarGenericSensor(coordinator, key, info, field, port=port))
+                    if _needs_derived_water_total(model, port_data):
+                        entities.append(HomGarWaterTotalSensor(coordinator, key, info, port=port))
                 # Shared top-level diagnostic fields (battery, rssi)
                 for field in sensor_fields_for_data(data):
                     if field not in (f for pd in [data.get(f"port_{p}", {}) for p in range(1, port_number + 1)] for f in pd):
@@ -153,6 +157,8 @@ async def async_setup_entry(
                     fields.update(_OPTIONAL_VALVE_PORT_SENSOR_FIELDS)
                 for field in sorted(fields):
                     entities.append(HomGarGenericSensor(coordinator, key, info, field))
+                if _needs_derived_water_total(model, data):
+                    entities.append(HomGarWaterTotalSensor(coordinator, key, info))
 
         # Only sub-devices that actually report a firmware version get the
         # sensor. RF accessories such as the rain gauge report nothing, and an
@@ -169,6 +175,22 @@ async def async_setup_entry(
 
     if entities:
         async_add_entities(entities)
+
+
+def _needs_derived_water_total(model: str | None, data: dict) -> bool:
+    """Whether this valve port needs a derived cumulative water total.
+
+    Only for devices that water and report no cumulative counter of their own.
+    A device already reporting ``total_water_volume`` from hardware keeps that
+    one — giving it a second, derived meter would double up the Energy
+    dashboard and invite the user to pick the wrong one. See issue #96.
+    """
+    if not model or not get_valve_ports(model):
+        return False
+    if "total_water_volume" in (data or {}):
+        return False
+    return "last_water_volume" in (data or {})
+
 
 
 class HomGarSensorBase(CoordinatorEntity, SensorEntity):
@@ -392,6 +414,72 @@ class HomGarGenericSensor(HomGarSensorBase):
                 value = None
         _LOGGER.debug("native_value for %s field=%s port=%s: %s", self._sensor_key, self._field_name, self._port, value)
         return value
+
+
+class HomGarWaterTotalSensor(HomGarGenericSensor, RestoreEntity):
+    """Cumulative water volume, derived by summing completed sessions.
+
+    Valves such as the HTV245FRF report only the most recent session's volume
+    and no cumulative counter, so Home Assistant's Energy / water dashboard had
+    nothing to consume. This accumulates each completed session instead. Created
+    only where the device reports no hardware total of its own, so a device that
+    has one never ends up with two competing meters. See issue #96.
+
+    The running total is restored across restarts via RestoreEntity. Sessions
+    that complete while Home Assistant is down are not visible to us at all —
+    the cloud only ever exposes the *latest* session — so they cannot be counted.
+    That is a property of the data, not of this implementation.
+    """
+
+    _ATTR_LAST_EVENT = "last_counted_event_time"
+
+    def __init__(self, coordinator, sensor_key, sensor_info, port=None) -> None:
+        super().__init__(coordinator, sensor_key, sensor_info, "water_total", port=port)
+        self._total: float = 0.0
+        self._last_event_time: int | None = None
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the running total before the first coordinator update."""
+        await super().async_added_to_hass()
+        last = await self.async_get_last_state()
+        if last is None:
+            return
+        try:
+            self._total = float(last.state)
+        except (TypeError, ValueError):
+            # "unknown"/"unavailable" from a previous run: start clean rather
+            # than crash. A restart-time reset is visible on the dashboard as a
+            # TOTAL_INCREASING meter reset, which is the honest signal.
+            return
+        stored = last.attributes.get(self._ATTR_LAST_EVENT)
+        if stored is not None:
+            try:
+                self._last_event_time = int(stored)
+            except (TypeError, ValueError):
+                self._last_event_time = None
+
+    def _accumulate(self) -> None:
+        src = self._source_data or {}
+        self._total, self._last_event_time = accumulate_session(
+            self._total,
+            self._last_event_time,
+            src.get("event_time_raw"),
+            src.get("last_water_volume"),
+        )
+
+    def _handle_coordinator_update(self) -> None:
+        self._accumulate()
+        super()._handle_coordinator_update()
+
+    @property
+    def native_value(self):
+        return round(self._total, 2)
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        attrs = dict(super().extra_state_attributes or {})
+        attrs[self._ATTR_LAST_EVENT] = self._last_event_time
+        return attrs
 
 
 class HomGarUnknownSensor(HomGarSensorBase):

--- a/custom_components/homgar/sensor_defs.py
+++ b/custom_components/homgar/sensor_defs.py
@@ -116,8 +116,21 @@ FIELD_SENSOR_MAP: dict[str, SensorDef | None] = {
     "last_water_volume": SensorDef(
         device_class=SensorDeviceClass.WATER,
         unit=UnitOfVolume.LITERS,
-        state_class=SensorStateClass.TOTAL,
+        # A per-session snapshot, NOT a meter. TOTAL made Home Assistant derive
+        # long-term statistics from the deltas between readings, so a 10 L
+        # session followed by a 2 L one recorded -8 L on the water dashboard.
+        # See issue #96.
+        state_class=SensorStateClass.MEASUREMENT,
         name="Last Session Volume",
+    ),
+    "water_total": SensorDef(
+        device_class=SensorDeviceClass.WATER,
+        unit=UnitOfVolume.LITERS,
+        # The meter the Energy dashboard actually wants. Derived by summing
+        # completed sessions, because these valves report no cumulative counter
+        # of their own. See water_total.py and issue #96.
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        name="Total Water Volume",
     ),
     "today_water_volume": SensorDef(
         device_class=SensorDeviceClass.WATER,

--- a/custom_components/homgar/water_total.py
+++ b/custom_components/homgar/water_total.py
@@ -1,0 +1,64 @@
+"""Derive a cumulative water total from per-session volumes.
+
+Issue #96: valves such as the HTV245FRF report only ``STA_LASTUSAGE`` — the
+volume of the most recent watering session — and carry no cumulative counter at
+all (no ``STA_WATER_TOTAL``, no ``STA_TOTAL_TODAY``). Home Assistant's Energy /
+water dashboard needs a monotonically increasing meter, so there was nothing on
+these devices to give it.
+
+This accumulates completed sessions into a running total instead.
+
+The session key is the device's own event timestamp, not the volume. Detecting
+"a new session" by watching the volume change is wrong in a way that loses data
+silently: two consecutive sessions of identical volume — the normal outcome of a
+fixed-duration schedule — look like one unchanged reading. The timestamp
+distinguishes them.
+"""
+from __future__ import annotations
+
+
+def accumulate_session(
+    total: float,
+    last_event_time: int | None,
+    event_time: int | None,
+    volume: float | None,
+) -> tuple[float, int | None]:
+    """Fold one polled reading into a running total.
+
+    Returns the new ``(total, last_event_time)`` pair. Pure, so the caller owns
+    persistence and this stays trivially testable.
+
+    The total feeds a ``TOTAL_INCREASING`` sensor, where any decrease is read by
+    Home Assistant as a meter reset and silently starts a new accumulation
+    cycle. Every branch below therefore either adds a non-negative amount or
+    leaves the total alone; none can reduce it.
+    """
+    # Nothing identifiable to count. Leave both values untouched rather than
+    # guessing, so a malformed poll cannot corrupt a good total.
+    if event_time is None:
+        return total, last_event_time
+
+    # Same session seen again. The coordinator polls every 120s while a
+    # completed session's volume just sits there, so this is the common path and
+    # must not accumulate.
+    if last_event_time is not None and event_time <= last_event_time:
+        return total, last_event_time
+
+    # A genuinely new session, but no volume in this payload yet. Hold the old
+    # key rather than adopting it: payloads can be partial, and the volume may
+    # arrive on a later poll for this same session. Advancing now would mean
+    # that session is never counted. Holding is safe — while the volume stays
+    # absent nothing accumulates, and once it appears it is counted exactly
+    # once, because the next comparison still sees a newer event time.
+    if volume is None:
+        return total, last_event_time
+
+    # Present but impossible. Unlike a missing value this will not improve on a
+    # later poll, so adopt the key and skip it — a negative would otherwise
+    # reduce a TOTAL_INCREASING total, which Home Assistant reads as a meter
+    # reset. Zero falls through below: a session that ran without flow is a
+    # real measurement and adding it is a no-op that correctly advances the key.
+    if volume < 0:
+        return total, event_time
+
+    return total + volume, event_time

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -15,6 +15,29 @@ bash scripts/pre-commit-docker-test.sh
 6. Create and push tag `vX.Y.Z`
 7. Create the GitHub release with `gh` using a notes file
 
+## Release Title Rule
+
+**Do not begin the release title with the version number.**
+
+HACS renders the update dialog as `<tag> - <release name>`, so a title of
+`v3.0.47 — a null status no longer blocks setup` displays to users as:
+
+```
+v3.0.47 - v3.0.47 — a null status no longer blocks setup
+```
+
+Title the release with the change only:
+
+```bash
+gh release create v3.0.47 \
+  --title "A null status no longer blocks setup, plus diagnostics downloads" \
+  --notes-file notes.md
+```
+
+Releases up to and including v3.0.46 repeat the version and render doubled in
+HACS. They are left as-is rather than retitled, since editing a published
+release rewrites what existing users already saw.
+
 ## Notes File Rule
 
 When using `gh`, write multi-line release notes to a file first and pass:

--- a/tests/run_water_total_tests.py
+++ b/tests/run_water_total_tests.py
@@ -1,0 +1,173 @@
+"""Tests for water-volume statistics: state class, and the derived running total.
+
+Issue #96: "Last Session Volume" could not drive Home Assistant's Energy/water
+dashboard, which showed negative values.
+
+Two distinct defects:
+
+1. ``last_water_volume`` was declared ``SensorStateClass.TOTAL``, which tells HA
+   the value is a cumulative meter and makes it derive long-term statistics from
+   the deltas between readings. It is not cumulative — it is a per-session
+   snapshot that drops back down after each run — so a 10 L session followed by
+   a 2 L one recorded a delta of -8 L. A per-session snapshot is MEASUREMENT.
+
+2. With that corrected there is still nothing to put on the dashboard, because
+   valves like the HTV245FRF report no cumulative total at all (their dp table
+   carries STA_LASTUSAGE but neither STA_WATER_TOTAL nor STA_TOTAL_TODAY). So we
+   derive one by accumulating each completed session.
+
+The accumulation is keyed on the session's event timestamp rather than on the
+volume changing: two consecutive sessions that happen to use the same volume are
+indistinguishable by value alone, and would silently lose a session.
+
+Runs in the ha-test container against the deployed integration at /config.
+"""
+import sys
+
+sys.path.insert(0, "/config")
+
+from homeassistant.components.sensor import SensorStateClass  # noqa: E402
+
+from custom_components.homgar.sensor_defs import FIELD_SENSOR_MAP  # noqa: E402
+from custom_components.homgar.water_total import accumulate_session  # noqa: E402
+
+PASS = 0
+FAIL = 0
+
+
+def check(name, cond, detail=""):
+    global PASS, FAIL
+    if cond:
+        print(f"  ✅ {name}"); PASS += 1
+    else:
+        print(f"  ❌ {name}{': ' + detail if detail else ''}"); FAIL += 1
+
+
+print("\n🧪 state class — a per-session snapshot is not a meter")
+
+lwv = FIELD_SENSOR_MAP["last_water_volume"]
+check(
+    "last_water_volume is MEASUREMENT, not TOTAL",
+    lwv.state_class == SensorStateClass.MEASUREMENT,
+    f"got {lwv.state_class!r}",
+)
+# The derived total is the one that belongs on the Energy dashboard.
+wt = FIELD_SENSOR_MAP.get("water_total")
+check("water_total is defined", wt is not None)
+check(
+    "water_total is TOTAL_INCREASING",
+    wt is not None and wt.state_class == SensorStateClass.TOTAL_INCREASING,
+    f"got {getattr(wt, 'state_class', None)!r}",
+)
+
+
+print("\n🧪 accumulate_session — one session counted exactly once")
+
+# (total, last_evtime, evtime, volume) -> (new_total, new_evtime)
+
+# First ever observation: adopt the session and count it.
+check(
+    "first observation counts the session",
+    accumulate_session(0.0, None, 1000, 5.5) == (5.5, 1000),
+    f"got {accumulate_session(0.0, None, 1000, 5.5)!r}",
+)
+# Repeated polls of the SAME session must not accumulate again — this is the
+# common case, since the coordinator polls every 120s while the value sits.
+check(
+    "same event time does not double count",
+    accumulate_session(5.5, 1000, 1000, 5.5) == (5.5, 1000),
+    f"got {accumulate_session(5.5, 1000, 1000, 5.5)!r}",
+)
+# A new session adds to the running total.
+check(
+    "a new event time adds the new session",
+    accumulate_session(5.5, 1000, 2000, 3.0) == (8.5, 2000),
+    f"got {accumulate_session(5.5, 1000, 2000, 3.0)!r}",
+)
+# The bug that value-based change detection would cause: two consecutive
+# sessions of identical volume must both be counted.
+check(
+    "two identical-volume sessions are both counted",
+    accumulate_session(5.0, 1000, 2000, 5.0) == (10.0, 2000),
+    f"got {accumulate_session(5.0, 1000, 2000, 5.0)!r}",
+)
+
+print("\n🧪 accumulate_session — never corrupt the total")
+
+# Missing data must leave the total untouched rather than adding None/zero noise.
+check(
+    "missing event time leaves the total unchanged",
+    accumulate_session(8.5, 2000, None, 4.0) == (8.5, 2000),
+    f"got {accumulate_session(8.5, 2000, None, 4.0)!r}",
+)
+check(
+    "missing volume leaves the total unchanged",
+    accumulate_session(8.5, 2000, 3000, None) == (8.5, 2000),
+    f"got {accumulate_session(8.5, 2000, 3000, None)!r}",
+)
+# A zero-volume session is a real event (valve opened, nothing flowed). It must
+# advance the session key so the NEXT real session is not mistaken for it.
+check(
+    "a zero-volume session still advances the event key",
+    accumulate_session(8.5, 2000, 3000, 0.0) == (8.5, 3000),
+    f"got {accumulate_session(8.5, 2000, 3000, 0.0)!r}",
+)
+# Defensive: a negative volume is never physical and must not reduce a
+# TOTAL_INCREASING total, which HA would read as a meter reset.
+check(
+    "a negative volume is ignored",
+    accumulate_session(8.5, 2000, 3000, -2.0) == (8.5, 3000),
+    f"got {accumulate_session(8.5, 2000, 3000, -2.0)!r}",
+)
+# An out-of-order/older event time (clock skew, stale cached payload) must not
+# re-count an earlier session.
+check(
+    "an older event time does not accumulate",
+    accumulate_session(8.5, 2000, 1500, 4.0) == (8.5, 2000),
+    f"got {accumulate_session(8.5, 2000, 1500, 4.0)!r}",
+)
+
+print("\n🧪 accumulate_session — monotonic, as TOTAL_INCREASING requires")
+
+total, ev = 0.0, None
+for i, (t, v) in enumerate([(100, 1.0), (100, 1.0), (200, 2.5), (200, 2.5), (300, 0.0), (400, 4.0)]):
+    new_total, ev = accumulate_session(total, ev, t, v)
+    check(f"step {i}: total never decreases", new_total >= total,
+          f"{total} -> {new_total}")
+    total = new_total
+check("final total is 1.0 + 2.5 + 0.0 + 4.0 = 7.5", total == 7.5, f"got {total}")
+
+
+print("\n🧪 _needs_derived_water_total — never compete with a hardware meter")
+
+from custom_components.homgar.sensor import _needs_derived_water_total  # noqa: E402
+
+check(
+    "a valve reporting only last-session volume gets a derived total",
+    _needs_derived_water_total("HTV245FRF", {"last_water_volume": 5.0}) is True,
+)
+# The important one: a device with a real hardware counter must NOT also get a
+# derived meter, or the Energy dashboard offers two totals for one valve.
+check(
+    "a valve already reporting a hardware total does not",
+    _needs_derived_water_total(
+        "HTV245FRF", {"last_water_volume": 5.0, "total_water_volume": 120.0}
+    ) is False,
+)
+check(
+    "a non-valve device does not",
+    _needs_derived_water_total("HCS012ARF", {"last_water_volume": 5.0}) is False,
+)
+check(
+    "a valve reporting no volume at all does not",
+    _needs_derived_water_total("HTV245FRF", {"battery_level": 80}) is False,
+)
+check("an unknown model does not", _needs_derived_water_total(None, {}) is False)
+
+
+print("\n" + "=" * 50)
+print(f"Results: {PASS}/{PASS + FAIL} passed, {FAIL} failed")
+if FAIL:
+    print("❌ TESTS FAILED")
+    sys.exit(1)
+print("✅ ALL TESTS PASSED")


### PR DESCRIPTION
Addresses #96 (left open until the reporter confirms).

## The bug

`sensor_defs.py` declared **Last Session Volume** as a cumulative meter:

```python
"last_water_volume": SensorDef(
    state_class=SensorStateClass.TOTAL,   # ← wrong
```

`TOTAL` tells Home Assistant the value is a meter, so it derives long-term statistics from the **difference between consecutive readings**. But this isn't a meter — it's a snapshot of the most recent watering session, and it drops back down after every run.

A 10 L session followed by a 2 L one was therefore recorded as **−8 L of water use**. That is exactly the reporter's symptom: *"Energy page shows negative values."*

A per-session snapshot is a `MEASUREMENT`.

## Why that fix alone isn't enough

With the state class corrected there is still nothing to put on the Energy dashboard, because these valves have no cumulative counter in hardware. The HTV245FRF's complete dp table:

```
CTL_WATER ×2   STA_LASTUSAGE ×2   STA_DURATION ×2
STA_EVTIME     ATTR_SHARE_FLOW    STA_BAT   STA_RSSI
```

`STA_LASTUSAGE` only — no `STA_WATER_TOTAL`, no `STA_TOTAL_TODAY`. So a total has to be derived.

## The derived total

A new **Total Water Volume** sensor per zone: `total_increasing`, accumulated from completed sessions, restored across restarts via `RestoreEntity` (the pattern already used in `number.py:107`).

**Sessions are keyed on the device's event timestamp, not on the volume changing.** This is the subtle part: detecting a new session by watching the value loses data silently, because two consecutive sessions using the same amount of water — the normal result of a fixed-duration schedule — look like one unchanged reading.

`accumulate_session()` is a pure function so the rules are directly testable:

| case | behaviour |
|---|---|
| same event time re-polled | no double count (the common path, polled every 120s) |
| new event time | adds the session |
| two identical volumes, different times | both counted |
| volume missing | total *and* key unchanged — the volume may arrive on a later poll for the same session |
| volume negative | key advances, value skipped (a decrease would read as a meter reset) |
| volume zero | counted as a real no-flow session, key advances |
| older event time | ignored |

**Created only where the hardware reports no total**, so a device already exposing a real counter never gains a second, competing meter.

## Known limit

Sessions completing while Home Assistant is stopped cannot be counted — the cloud only ever exposes the *most recent* session, so there is no history to catch up on. Documented in the module rather than worked around.

## Not doing

The reporter also asked for parent/child valve aggregation. A main valve and the valves behind it measure overlapping water, so summing them double-counts; which sensors belong on the dashboard is a plumbing-topology decision only the user can make. Better served by a template than by guessing in the integration.

## Upgrade note

Correcting the state class discards the `sum` statistics previously accumulated for these sensors. Those sums were the negative ones, so this is a cleanup rather than a loss, but users may see a one-off statistics notice.

## Testing

- New `tests/run_water_total_tests.py` — 24 assertions, written test-first (one caught a real design error: my first implementation advanced the session key on a missing volume, which would have dropped a session whose volume arrived late)
- All **31** runners pass; decoder suite **84/84**
- Verified on `ha-test`: `last_session_volume` now `[measurement]`, `total_water_volume` created as `[total_increasing]`, clean restart with no errors