### PR TITLE
fix(sensor): Total Water Volume never counted on TLV devices (v3.0.49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.0.49] - 2026-08-30
+
+### 🐛 Bug Fixes
+- **Total Water Volume now actually counts** — the sensor added in v3.0.48 never left `0.00 L`. Reported on [#96](https://github.com/brettmeyerowitz/homeassistant-homgar/issues/96) by [@thomasgraf99](https://github.com/thomasgraf99) and [@Semir333](https://github.com/Semir333), who between them field-tested it on real hardware and identified the failing code path.
+  - A session is counted using the device's event timestamp, but the accumulator read only `event_time_raw` — a field the **legacy** payload decoder sets. Devices on the **TLV** path, including the HTV245FRF, expose the same event solely as an ISO-8601 string in `event_time`. The key was therefore always absent, and the accumulator correctly declined to count a session it could not identify. It now accepts either representation.
+  - Measured against the payload corpus, the old logic produced a usable key for **0 of 12** TLV payload sections carrying an event time; it now produces 12.
+  - The v3.0.48 tests all passed while the sensor was incapable of counting anything, because they exercised the accumulator in isolation and never asked whether the field it reads exists in real decoded output. A regression test now runs every corpus payload through the decoder and asserts a usable key comes out of both decode paths.
+
+### ⬆️ Upgrading
+- Totals start from zero on upgrade. Sessions that ran while the sensor was stuck cannot be recovered — the cloud only ever exposes the most recent session.
+
 ## [3.0.48] - 2026-08-28
 
 ### 🐛 Bug Fixes

--- a/custom_components/homgar/manifest.json
+++ b/custom_components/homgar/manifest.json
@@ -15,5 +15,5 @@
     "requirements": [
         "paho-mqtt>=1.6.0"
     ],
-    "version": "3.0.48"
+    "version": "3.0.49"
 }

--- a/custom_components/homgar/sensor.py
+++ b/custom_components/homgar/sensor.py
@@ -29,7 +29,7 @@ from .const import (
 )
 from .coordinator import HomGarCoordinator, _clean_firmware
 from .sensor_defs import FIELD_SENSOR_MAP, sensor_fields_for_data
-from .water_total import accumulate_session
+from .water_total import accumulate_session, session_key
 from .decoder import get_valve_ports
 from .diagnostic_sensors import (
     HomGarFirmwareVersionSensor,
@@ -463,7 +463,7 @@ class HomGarWaterTotalSensor(HomGarGenericSensor, RestoreEntity):
         self._total, self._last_event_time = accumulate_session(
             self._total,
             self._last_event_time,
-            src.get("event_time_raw"),
+            session_key(src),
             src.get("last_water_volume"),
         )
 

--- a/custom_components/homgar/water_total.py
+++ b/custom_components/homgar/water_total.py
@@ -16,6 +16,39 @@ distinguishes them.
 """
 from __future__ import annotations
 
+from datetime import datetime
+from typing import Any, Mapping
+
+
+def session_key(source: Mapping[str, Any]) -> int | None:
+    """Return the session's event time as a Unix timestamp, or None.
+
+    The two decode paths expose the same event differently, and reading only one
+    of them shipped a sensor that could never count anything (v3.0.48, #96):
+
+    * legacy payloads set ``event_time_raw`` (int) *and* ``event_time`` (ISO)
+    * TLV payloads — the HTV245FRF and most current hardware — set only
+      ``event_time`` as an ISO-8601 string
+
+    Keying on ``event_time_raw`` alone therefore worked on exactly the devices
+    nobody reported, and never on the ones that did. Accept either shape.
+    """
+    raw = source.get("event_time_raw")
+    if isinstance(raw, (int, float)) and not isinstance(raw, bool) and raw > 0:
+        return int(raw)
+
+    value = source.get("event_time")
+    if isinstance(value, (int, float)) and not isinstance(value, bool) and value > 0:
+        return int(value)
+    if isinstance(value, str) and value:
+        try:
+            return int(datetime.fromisoformat(value).timestamp())
+        except ValueError:
+            # A malformed timestamp must not become a key: a wrong one either
+            # double counts a session or hides a real one.
+            return None
+    return None
+
 
 def accumulate_session(
     total: float,

--- a/tests/run_water_total_tests.py
+++ b/tests/run_water_total_tests.py
@@ -165,6 +165,85 @@ check(
 check("an unknown model does not", _needs_derived_water_total(None, {}) is False)
 
 
+print("\n🧪 session_key — the event time must be found on BOTH decode paths")
+
+from custom_components.homgar.water_total import session_key  # noqa: E402
+
+# Regression for the v3.0.48 field bug (#96). The accumulator read only
+# ``event_time_raw``, which the LEGACY decode path populates. Devices on the TLV
+# path — the HTV245FRF among them — expose the same event only as an ISO string
+# in ``event_time``, so the key was always None and the total never moved.
+# Two reporters confirmed it stuck at 0.00 L with last_counted_event_time unknown.
+check(
+    "legacy shape: reads the raw integer",
+    session_key({"event_time_raw": 1776110281,
+                 "event_time": "2026-04-13T19:58:01+00:00"}) == 1776110281,
+    f"got {session_key({'event_time_raw': 1776110281})!r}",
+)
+check(
+    "TLV shape: parses the ISO string when no raw value exists",
+    session_key({"event_time": "2026-04-11T20:51:43+00:00"}) == 1775940703,
+    f"got {session_key({'event_time': '2026-04-11T20:51:43+00:00'})!r}",
+)
+check(
+    "an integer event_time is accepted directly",
+    session_key({"event_time": 1776110281}) == 1776110281,
+)
+# Ordering must survive the string form, or a newer session could look older.
+a = session_key({"event_time": "2026-04-11T20:51:43+00:00"})
+b = session_key({"event_time": "2026-04-13T19:58:01+00:00"})
+check("parsed keys preserve chronological order", a < b, f"{a} !< {b}")
+
+print("\n🧪 session_key — never invent a key")
+
+for bad, label in [
+    ({}, "no fields at all"),
+    ({"event_time": None, "event_time_raw": None}, "explicit nulls"),
+    ({"event_time": ""}, "empty string"),
+    ({"event_time": "not a timestamp"}, "unparseable string"),
+    ({"event_time_raw": 0}, "zero raw value"),
+]:
+    check(f"returns None for {label}", session_key(bad) is None,
+          f"got {session_key(bad)!r}")
+
+
+print("\n🧪 end-to-end — a REAL decoded payload must yield a usable key")
+
+# The test that was missing in v3.0.48. Every unit test passed while the sensor
+# was incapable of counting anything, because none of them ran a real payload
+# through the decoder and asked whether the field the sensor reads is actually
+# there. This closes that gap: it fails if either decode path stops exposing an
+# event time under a name session_key() understands.
+import glob, json  # noqa: E402
+from custom_components.homgar.decoder import decode_payload  # noqa: E402
+
+checked = {}
+for path in sorted(glob.glob("/tmp/fx/payloads/*.json")):
+    doc = json.load(open(path))
+    model = doc.get("model")
+    for sample in doc.get("samples", []):
+        try:
+            out = decode_payload(model, sample["payload"])
+        except Exception:
+            continue
+        sections = [out] + [v for k, v in out.items()
+                            if k.startswith("port_") and isinstance(v, dict)]
+        for sec in sections:
+            if sec.get("event_time") is None and sec.get("event_time_raw") is None:
+                continue
+            fmt = sample.get("format", "?")
+            key = session_key(sec)
+            checked.setdefault(fmt, []).append((model, sample.get("id"), key))
+
+for fmt in ("tlv", "legacy"):
+    got = checked.get(fmt) or []
+    check(f"a {fmt} payload carrying an event time was found in the corpus",
+          bool(got), "no sample exercised this path")
+    for model, sid, key in got:
+        check(f"{fmt}: {model} {str(sid)[:22]} yields a usable key",
+              isinstance(key, int) and key > 0, f"got {key!r}")
+
+
 print("\n" + "=" * 50)
 print(f"Results: {PASS}/{PASS + FAIL} passed, {FAIL} failed")
 if FAIL:


### PR DESCRIPTION
Fixes a regression I shipped in **v3.0.48**. Reported on #96 by @thomasgraf99 and @Semir333, who field-tested it on real hardware and identified the failing code path between them.

## The symptom

`Zone 2 Last Session Volume` updated correctly to **16.30 L** after a completed run. `Zone 2 Total Water Volume` stayed at **0.00 L**, with `last_counted_event_time` never leaving `unknown`.

## Root cause

A session is counted using the device's event timestamp. The accumulator read only `event_time_raw` — and that field is set **exclusively by the legacy payload decoder** (`_decode_legacy_port_section`, decoder.py:458).

Devices on the **TLV** path, including the HTV245FRF, expose the same event only as an ISO-8601 string in `event_time`. Decoding a real payload from each path shows it plainly:

```
format   model        event_time                    event_time_raw
tlv      HCS008FRF    '2026-04-11T20:51:43+00:00'   None      ← key absent
legacy   HTV245FRF    '2026-04-13T19:58:01+00:00'   1776110281
```

So the key was always `None`, and `accumulate_session()` did exactly what it was designed to do — decline to count a session it cannot identify. The bug was upstream of it, in which field the sensor handed it.

`session_key()` now resolves either representation.

## Measured

Against the payload corpus, TLV sections that carry an event time:

| | usable key produced |
|---|---|
| v3.0.48 (`event_time_raw` only) | **0 of 12** |
| this fix (`session_key`) | **12 of 12** |

## Why the tests didn't catch it

Every v3.0.48 test passed while the sensor was incapable of counting anything. They exercised `accumulate_session()` in isolation with hand-built dicts and never asked whether the field the sensor reads is present in real decoded output.

Added an end-to-end regression test that runs **every corpus payload** through the decoder and asserts both decode paths yield a usable key. I verified it fails against the old logic rather than assuming it would — that's the check that was missing.

## Upgrade note

Totals start from zero. Sessions that ran while the sensor was stuck cannot be recovered — the cloud only ever exposes the most recent session.

## Testing

- 31 runners pass (50 assertions in this suite); decoder corpus 84/84
- Clean restart on `ha-test`, no errors