### PR TITLE
fix(sensor): Last Session Volume logged an invalid state class (v3.0.50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.0.50] - 2026-08-31
+
+### 🐛 Bug Fixes
+- **"Last Session Volume" no longer logs a warning on every startup** — reported in [#103](https://github.com/brettmeyerowitz/homeassistant-homgar/issues/103) by [@deanpomerleau](https://github.com/deanpomerleau). Home Assistant logged `is using state class 'measurement' which is impossible considering device class ('water')` once per affected entity.
+  - Introduced by the v3.0.48 fix for [#96](https://github.com/brettmeyerowitz/homeassistant-homgar/issues/96). That change moved the sensor off `total` — correctly, since a per-session snapshot is not a meter and `total` was producing negative figures on the Energy dashboard — but `measurement` is not a legal alternative: Home Assistant permits only `total` or `total_increasing` alongside `device_class: water`.
+  - The sensor now declares **no state class at all**. It keeps `device_class: water` so the value is still presented and converted as a volume, while generating no long-term statistics — which is exactly what the #96 fix needed. **Total Water Volume** remains the sensor for the Energy dashboard.
+  - Verified by reproduction rather than by reasoning: reinstating the old value produced 7 warnings on a live restart, and removing it produced none.
+  - Every sensor definition we ship is now validated against Home Assistant's own `DEVICE_CLASS_STATE_CLASSES` table in the test suite, so this class of mistake fails a test rather than a user's log. The audit found exactly one invalid pair — this one.
+
 ## [3.0.49] - 2026-08-30
 
 ### 🐛 Bug Fixes

--- a/custom_components/homgar/manifest.json
+++ b/custom_components/homgar/manifest.json
@@ -15,5 +15,5 @@
     "requirements": [
         "paho-mqtt>=1.6.0"
     ],
-    "version": "3.0.49"
+    "version": "3.0.50"
 }

--- a/custom_components/homgar/sensor_defs.py
+++ b/custom_components/homgar/sensor_defs.py
@@ -116,11 +116,14 @@ FIELD_SENSOR_MAP: dict[str, SensorDef | None] = {
     "last_water_volume": SensorDef(
         device_class=SensorDeviceClass.WATER,
         unit=UnitOfVolume.LITERS,
-        # A per-session snapshot, NOT a meter. TOTAL made Home Assistant derive
-        # long-term statistics from the deltas between readings, so a 10 L
-        # session followed by a 2 L one recorded -8 L on the water dashboard.
-        # See issue #96.
-        state_class=SensorStateClass.MEASUREMENT,
+        # No state class at all, deliberately. This is a per-session snapshot,
+        # not a meter: TOTAL made Home Assistant derive statistics from the
+        # deltas between readings, so a 10 L session followed by a 2 L one
+        # recorded -8 L on the water dashboard (#96). MEASUREMENT is not a legal
+        # alternative — HA permits only total/total_increasing with
+        # device_class water, and warned on every startup (#103). Omitting it
+        # keeps the volume formatting while generating no statistics, which is
+        # exactly what a snapshot warrants. Total Water Volume is the meter.
         name="Last Session Volume",
     ),
     "water_total": SensorDef(

--- a/tests/run_sensor_def_validity_tests.py
+++ b/tests/run_sensor_def_validity_tests.py
@@ -1,0 +1,93 @@
+"""Every sensor definition must be a combination Home Assistant accepts.
+
+Issue #103: v3.0.48 set ``last_water_volume`` to ``state_class: measurement``
+to stop it producing bogus statistics (#96). That fixed the statistics but
+created a new problem — Home Assistant does not allow ``measurement`` with
+``device_class: water``, so every affected entity logged a warning on each
+startup:
+
+    Entity sensor...last_session_volume is using state class 'measurement'
+    which is impossible considering device class ('water') it is using;
+    expected None or one of 'total_increasing', 'total'
+
+The correct value for a per-session snapshot is **no state class at all**:
+``device_class: water`` is retained so the value is presented and converted as a
+volume, while the absence of a state class means Home Assistant derives no
+long-term statistics from it — which was the whole point of the #96 fix.
+
+Rather than assert only the field that broke, this validates every definition
+we ship against Home Assistant's own ``DEVICE_CLASS_STATE_CLASSES`` table, so
+the entire class of mistake is caught here instead of in a user's log.
+
+Runs in the ha-test container against the deployed integration at /config.
+"""
+import sys
+
+sys.path.insert(0, "/config")
+
+from homeassistant.components.sensor import DEVICE_CLASS_STATE_CLASSES  # noqa: E402
+
+from custom_components.homgar.sensor_defs import FIELD_SENSOR_MAP  # noqa: E402
+
+PASS = 0
+FAIL = 0
+
+
+def check(name, cond, detail=""):
+    global PASS, FAIL
+    if cond:
+        print(f"  ✅ {name}"); PASS += 1
+    else:
+        print(f"  ❌ {name}{': ' + detail if detail else ''}"); FAIL += 1
+
+
+print("\n🧪 every device_class / state_class pair is one Home Assistant permits")
+
+checked = 0
+for field, sdef in sorted(FIELD_SENSOR_MAP.items()):
+    if sdef is None:
+        continue
+    device_class = getattr(sdef, "device_class", None)
+    state_class = getattr(sdef, "state_class", None)
+    # A definition that declares neither, or omits the state class, is always
+    # fine — Home Assistant only constrains the combination of the two.
+    if device_class is None or state_class is None:
+        continue
+    allowed = DEVICE_CLASS_STATE_CLASSES.get(device_class)
+    if allowed is None:
+        continue
+    checked += 1
+    check(
+        f"{field} ({device_class.value} / {state_class.value})",
+        state_class in allowed,
+        f"allowed: {sorted(s.value for s in allowed)}",
+    )
+
+check("at least one pair was actually validated", checked > 0,
+      "the table lookup silently matched nothing — the guard is not working")
+
+
+print("\n🧪 the specific regression from #103")
+
+lwv = FIELD_SENSOR_MAP["last_water_volume"]
+# Not 'measurement' (impossible for water), and not 'total'/'total_increasing'
+# either — those are what produced the negative Energy dashboard figures in #96,
+# because a per-session snapshot is not a meter.
+check(
+    "last_water_volume declares no state class at all",
+    lwv.state_class is None,
+    f"got {lwv.state_class!r}",
+)
+check(
+    "last_water_volume keeps device_class water for unit handling",
+    lwv.device_class is not None and lwv.device_class.value == "water",
+    f"got {lwv.device_class!r}",
+)
+
+
+print("\n" + "=" * 50)
+print(f"Results: {PASS}/{PASS + FAIL} passed, {FAIL} failed")
+if FAIL:
+    print("❌ TESTS FAILED")
+    sys.exit(1)
+print("✅ ALL TESTS PASSED")

--- a/tests/run_water_total_tests.py
+++ b/tests/run_water_total_tests.py
@@ -9,7 +9,8 @@ Two distinct defects:
    the value is a cumulative meter and makes it derive long-term statistics from
    the deltas between readings. It is not cumulative — it is a per-session
    snapshot that drops back down after each run — so a 10 L session followed by
-   a 2 L one recorded a delta of -8 L. A per-session snapshot is MEASUREMENT.
+   a 2 L one recorded a delta of -8 L. It now declares no state class at all:
+   MEASUREMENT was tried first and is illegal for device_class water (#103).
 
 2. With that corrected there is still nothing to put on the dashboard, because
    valves like the HTV245FRF report no cumulative total at all (their dp table
@@ -46,9 +47,13 @@ def check(name, cond, detail=""):
 print("\n🧪 state class — a per-session snapshot is not a meter")
 
 lwv = FIELD_SENSOR_MAP["last_water_volume"]
+# Not TOTAL — that produced the negative Energy dashboard figures (#96) — and
+# not MEASUREMENT either, which Home Assistant rejects outright for
+# device_class water and warned about on every startup (#103). A per-session
+# snapshot simply has no state class; see run_sensor_def_validity_tests.py.
 check(
-    "last_water_volume is MEASUREMENT, not TOTAL",
-    lwv.state_class == SensorStateClass.MEASUREMENT,
+    "last_water_volume declares no state class",
+    lwv.state_class is None,
     f"got {lwv.state_class!r}",
 )
 # The derived total is the one that belongs on the Energy dashboard.


### PR DESCRIPTION
Addresses #103, reported by @deanpomerleau. A regression I introduced in v3.0.48.

## The warning

```
Entity sensor...last_session_volume is using state class 'measurement' which is
impossible considering device class ('water') it is using; expected None or one
of 'total_increasing', 'total'
```

Once per affected entity, on every startup.

## Cause

The v3.0.48 fix for #96 moved this sensor off `total`. That part was right — a per-session snapshot is not a meter, and `total` made Home Assistant derive statistics from the deltas, producing negative figures on the Energy dashboard.

But `measurement` is not a legal alternative. Checked against HA's own table:

```
water   -> ['total', 'total_increasing']
energy  -> ['total', 'total_increasing']
volume  -> ['total', 'total_increasing']
```

So the sensor was valid for statistics purposes and invalid as a declaration.

## Fix

It now declares **no state class at all**. `device_class: water` is retained so the value is still formatted and converted as a volume, while no long-term statistics are derived from it — exactly what #96 required. **Total Water Volume** remains the Energy dashboard meter.

## Verified by reproduction, not reasoning

| container state | warnings on live restart |
|---|---|
| `state_class=MEASUREMENT` (v3.0.49) | **7** |
| no state class (this PR) | **0** |

Same hardware, same restart procedure, nothing else changed.

## Preventing the class of bug

This is the third field/declaration assumption in four days that only surfaced in a user's environment. Rather than fix the one field, `tests/run_sensor_def_validity_tests.py` now validates **every** shipped sensor definition against HA's `DEVICE_CLASS_STATE_CLASSES`, so an illegal pair fails a test instead of a log.

The audit found exactly one invalid pair — this one. The other 25 definitions are clean.

## Testing

- 32 runners pass; decoder corpus 84/84
- Live restart on `ha-test`: 0 state-class warnings, 0 integration errors