### PR TITLE
fix: duplicate catalogue rows erase a device's zones (v3.0.51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.0.51] - 2026-09-07
+
+### 🐛 Bug Fixes
+- **Multi-zone WiFi controllers get their zones back** — reported in [#108](https://github.com/brettmeyerowitz/homeassistant-homgar/issues/108) by [@geoffly](https://github.com/geoffly), whose six-zone HIC819W-6 was discovered correctly but produced no valve entities at all.
+  - The vendor catalogue lists some models **twice**: once as a category 1 "main device" row with `portNumber: 0` and a few dp definitions, and once as a category 6 row carrying the real port count and the full dp set. The model registry was built by assignment in list order, so the **last** row silently won — and for these models that is the empty one.
+  - Five shipped models were affected, losing every zone: `HIC1208W` (8), `HIC819W-6` (6), `HIC819W-4` (4), `HPS551WRF` and `HWS388WRF-V7`. The controller still appeared in Home Assistant with its diagnostic entities, so it read as an unsupported device rather than a lookup bug — which is likely why it went unreported.
+  - The registry now keeps the row that actually describes the device: ports first, dp count as the tie-break.
+  - Verified against the reporter's own payload from his diagnostics: it decoded to `port_number: 1` with no zones before the change and to six ports after. That payload is now part of the test corpus.
+  - This also removes an ordering dependency rather than patching one symptom. `HIC801W` was working only because its useful row happens to come last in the vendor's list; any reshuffle of the catalogue would have silently cost it all 8 zones.
+
 ## [3.0.50] - 2026-08-31
 
 ### 🐛 Bug Fixes

--- a/custom_components/homgar/decoder.py
+++ b/custom_components/homgar/decoder.py
@@ -39,12 +39,32 @@ def _build_model_registry() -> dict[str, dict]:
     result: dict[str, dict] = {}
     for m in data["data"]["models"]:
         key = m["model"]
-        result[key] = m
+        current = result.get(key)
+        if current is None or _describes_device_better(m, current):
+            result[key] = m
         dm = m.get("displayModel", "")
         if dm and dm != key and dm not in result:
             result[dm] = m
     _LOGGER.debug("Loaded %d models from product_models.json", len(result))
     return result
+
+
+def _describes_device_better(candidate: dict, current: dict) -> bool:
+    """Whether ``candidate`` is the more useful of two rows for the same model.
+
+    The vendor lists some models twice: once as a category 1 "main device" row
+    with portNumber 0 and a few dp definitions, and once as a category 6 row
+    carrying the real port count and the full dp set. Taking whichever came
+    last (issue #108) meant seven multi-zone controllers — up to twelve zones —
+    resolved to the empty row and produced no valve entities at all.
+
+    Ports first, dp count as the tie-break: a row that knows how many zones a
+    device has is describing the device, not just naming it.
+    """
+    def rank(m: dict) -> tuple[int, int]:
+        return (m.get("portNumber") or 0, len(m.get("dp") or []))
+
+    return rank(candidate) > rank(current)
 
 
 _MODELS: dict[str, dict] = _build_model_registry()

--- a/custom_components/homgar/manifest.json
+++ b/custom_components/homgar/manifest.json
@@ -15,5 +15,5 @@
     "requirements": [
         "paho-mqtt>=1.6.0"
     ],
-    "version": "3.0.50"
+    "version": "3.0.51"
 }

--- a/scripts/pre-commit-docker-test.sh
+++ b/scripts/pre-commit-docker-test.sh
@@ -230,6 +230,16 @@ else
     exit 1
 fi
 
+# ── Test: model registry duplicate resolution ─────────────────────────────
+echo "🧪 Running model registry regression tests..."
+docker cp tests/run_model_registry_tests.py ha-test:/tmp/tests/run_model_registry_tests.py > /dev/null
+if docker exec ha-test python3 /tmp/tests/run_model_registry_tests.py; then
+    echo "✅ Model registry regression tests passed"
+else
+    echo "❌ ERROR: Model registry regression tests failed"
+    exit 1
+fi
+
 # ── Test: MQTT parser regressions ─────────────────────────────────────────
 echo "🧪 Running MQTT parser regression tests..."
 docker cp tests/run_mqtt_parser_tests.py ha-test:/tmp/tests/run_mqtt_parser_tests.py > /dev/null

--- a/tests/fixtures/payloads/HIC819W-6.json
+++ b/tests/fixtures/payloads/HIC819W-6.json
@@ -1,0 +1,17 @@
+{
+  "model": "HIC819W-6",
+  "samples": [
+    {
+      "id": "issue-108-six-zone-idle",
+      "source_issue": 108,
+      "source_type": "live_capture",
+      "format": "tlv",
+      "payload": "10#108800AF00000000B700403F03D800F700000000F9FF00",
+      "expected": {
+        "port_number": 6,
+        "port_1": {"present": true},
+        "port_6": {"present": true}
+      }
+    }
+  ]
+}

--- a/tests/run_model_registry_tests.py
+++ b/tests/run_model_registry_tests.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Regression tests: duplicate model names must not lose a device's zones.
+
+Issue #108, reported by @geoffly. A Pihode HIC819W-6 six-zone controller was
+discovered but produced no valve entities at all.
+
+The vendor catalogue lists some models TWICE — once as a category 1 "main
+device" row with portNumber 0 and a handful of dp definitions, and once as a
+category 6 row carrying the real portNumber and the full dp set. The registry
+was built with ``result[key] = m`` in list order, so the LAST entry silently
+won. For seven models that is the empty one, and every zone disappeared.
+
+The reporter's own payload is the fixture: it decodes to port_number 1 with the
+empty entry and to six ports with the right one, so this asserts behaviour
+against real hardware rather than a constructed example.
+"""
+import sys
+
+sys.path.insert(0, "/config")
+
+from custom_components.homgar.decoder import (  # noqa: E402
+    decode_payload,
+    get_model_info,
+    get_valve_ports,
+)
+
+PASS = 0
+FAIL = 0
+
+
+def check(name, cond, detail=""):
+    global PASS, FAIL
+    if cond:
+        PASS += 1
+        print(f"  ✅ {name}")
+    else:
+        FAIL += 1
+        print(f"  ❌ {name} {detail}")
+
+
+# Every model that loses its zones to the last-entry-wins collision, with the
+# port count the catalogue actually describes.
+AFFECTED = {
+    "HIC1200W": 12,
+    "HIC1208W": 8,
+    "HIC819W-6": 6,
+    "HIC819W-4": 4,
+    "HIC1204W": 4,
+    "HPS551WRF": 1,
+    "HWS388WRF-V7": 1,
+}
+
+print("\n🧪 duplicate catalogue entries resolve to the row that describes the device")
+
+for model, ports in sorted(AFFECTED.items()):
+    info = get_model_info(model)
+    check(
+        f"{model} keeps its {ports} port(s)",
+        info is not None and (info.get("portNumber") or 0) == ports,
+        f"got portNumber={None if info is None else info.get('portNumber')}",
+    )
+
+print("\n🧪 issue #108 — the reporter's own HIC819W-6 payload")
+
+# Straight from the diagnostics attached to the issue.
+PAYLOAD = "10#108800AF00000000B700403F03D800F700000000F9FF00"
+
+check(
+    "get_valve_ports reports all six zones",
+    get_valve_ports("HIC819W-6") == [1, 2, 3, 4, 5, 6],
+    f"got {get_valve_ports('HIC819W-6')}",
+)
+
+decoded = decode_payload("HIC819W-6", PAYLOAD)
+check(
+    "the payload decodes to six ports, not one",
+    decoded.get("port_number") == 6,
+    f"got {decoded.get('port_number')}",
+)
+check(
+    "a port block exists for every zone",
+    all(f"port_{p}" in decoded for p in range(1, 7)),
+    f"got {sorted(k for k in decoded if k.startswith('port_'))}",
+)
+
+print(f"\n{PASS} passed, {FAIL} failed")
+sys.exit(1 if FAIL else 0)


### PR DESCRIPTION
Hotfix off `main` so this reaches users without waiting on #107. Reported in #108 by @geoffly, whose six-zone HIC819W-6 was discovered correctly but produced **no valve entities at all**.

## Cause

The vendor catalogue lists some models **twice**:

| `HIC819W-6` row | category | `portNumber` | dp definitions |
|---|---|---:|---:|
| first | 6 | **6** | 16 ← describes the zones |
| last | 1 | **0** | 7 |

`_build_model_registry()` used `result[key] = m` in list order, so the **last** row silently won. We kept the zero-port row, `get_valve_ports()` returned `[]`, and no valve entities were built.

That matches the report exactly: the raw data is right (`zoneNum: 6`, `portNumber: 6`, all six zone names) while the processed data reads `port_number: 1`. The controller was reporting its zones correctly; our lookup discarded the half of the entry that described them.

## Affected in the shipped catalogue

`HIC1208W` (8 zones), `HIC819W-6` (6), `HIC819W-4` (4), `HPS551WRF`, `HWS388WRF-V7` — each losing **every** zone.

Because the device still appeared with its diagnostic entities, this looked like "my controller isn't supported yet" rather than a bug, which is likely why it went unreported until now.

## Verified against real hardware we don't own

The reporter's `D01` frame, taken from the diagnostics he attached:

```
before   port_number: 1   valve ports: []
after    port_number: 6   valve ports: [1, 2, 3, 4, 5, 6]
```

That payload is now a corpus fixture (`HIC819W-6.json`, `source_issue: 108`), so the regression is locked against behaviour rather than an assumption.

## Why this is more than a five-model fix

It removes an **ordering dependency**, not just its current symptom. `HIC801W` works today only because its useful row happens to come *last* in the vendor's list:

```
HIC801W        rows = [(cat 6, 8 ports), (cat 1, 0 ports), (cat 6, 8 ports)]  → keeps 8
HWS388WRF-V7   rows = [(cat 6, 1 port),  (cat 6, 1 port),  (cat 1, 0 ports)]  → keeps 0
```

Identical hazard, opposite outcome, decided purely by list order. Any catalogue reshuffle would have silently cost `HIC801W` all 8 zones — and it has more installs in telemetry than any currently-affected model. That failure would have looked like an unrelated regression on a routine data update.

## Testing

84/84 decoder checks and 33/33 runners in `ha-test`, against **this branch's** (older) catalogue rather than the refreshed one. `run_model_registry_tests.py` is wired into `pre-commit-docker-test.sh`.

## Note

Deliberately no closing keyword — the issue stays open until @geoffly confirms on his own hardware.

The same fix is also present in #107, where the refreshed catalogue makes it matter more (`HIC1200W` gains a duplicate row there and would drop from 12 zones to 0). Merging this first will conflict trivially in `CHANGELOG.md` and `manifest.json`; #107 keeps its own `3.1.0` entry.